### PR TITLE
fix: Regroup bundle items and set placeholder image to LineItemImage

### DIFF
--- a/pages/checkout/index.tsx
+++ b/pages/checkout/index.tsx
@@ -900,11 +900,11 @@ export default function Main() {
                       <div className="text-gray-500 ml-5">
                         <PaymentSourceDetail
                           data-cy="payment-exp-month"
-                          type="expMonth"
+                          type="exp_month"
                         />
                         <PaymentSourceDetail
                           data-cy="payment-exp-year"
-                          type="expYear"
+                          type="exp_year"
                         />
                       </div>
                       <div className="ml-5">
@@ -989,7 +989,13 @@ export default function Main() {
                 </LineItem>
                 <LineItem type="adjustments">
                   <div className="flex justify-between items-center border-b p-5">
-                    <LineItemImage className="p-2" width={40} />
+                    <LineItemImage
+                      className="p-2"
+                      width={40}
+                      placeholder={{
+                        adjustments: '',
+                      }}
+                    />
                     <LineItemName data-test="line-item-name" className="p-2" />
                     <LineItemAmount
                       data-test="line-item-total"

--- a/src/components/LineItem.tsx
+++ b/src/components/LineItem.tsx
@@ -29,6 +29,7 @@ const LineItem: FunctionComponent<LineItemProps> = (props) => {
     items
       .filter((l) => l.item_type === type)
       .map((lineItem, k) => {
+        if (lineItem.item_type === 'bundles' && k > 0) return null
         const lineProps = {
           lineItem,
         }

--- a/src/components/LineItemImage.tsx
+++ b/src/components/LineItemImage.tsx
@@ -3,6 +3,12 @@ import Parent from './utils/Parent'
 import LineItemChildrenContext from '#context/LineItemChildrenContext'
 import components from '#config/components'
 import { LineItem } from '@commercelayer/sdk'
+import { LineItemType } from '#typings'
+
+const defaultImgUrl =
+  'https://data.commercelayer.app/assets/images/placeholders/img_placeholder.svg'
+const defaultGiftCardImgUrl =
+  'https://data.commercelayer.app/assets/images/placeholders/gift_placeholder.svg'
 
 const propTypes = components.LineItemImage.propTypes
 const displayName = components.LineItemImage.displayName
@@ -15,20 +21,33 @@ export type LineItemImageType = Omit<LineItemImageProps, 'children'> & {
 type LineItemImageProps = {
   children?: (props: LineItemImageType) => ReactNode
   width?: number
-} & Omit<JSX.IntrinsicElements['img'], 'src' | 'srcSet'>
+  placeholder?: {
+    [K in LineItemType]?: string
+  }
+} & Omit<JSX.IntrinsicElements['img'], 'src' | 'srcSet' | 'placeholder'>
 
 const LineItemImage: FunctionComponent<LineItemImageProps> = (props) => {
+  const { placeholder, children, ...p } = props
   const { lineItem } = useContext(LineItemChildrenContext)
-  const src = lineItem?.image_url
+  const itemType = lineItem?.item_type as LineItemType
+  let src = lineItem?.image_url
+  if (!src) {
+    if (placeholder?.[itemType]) {
+      src = placeholder?.[itemType]
+    } else {
+      src = itemType === 'gift_cards' ? defaultGiftCardImgUrl : defaultImgUrl
+    }
+  }
   const parenProps = {
     lineItem,
     src,
-    ...props,
+    placeholder,
+    ...p,
   }
-  return props.children ? (
-    <Parent {...parenProps}>{props.children}</Parent>
-  ) : (
-    <img alt="" src={src} {...props} />
+  return children ? (
+    <Parent {...parenProps}>{children}</Parent>
+  ) : !src ? null : (
+    <img alt="" src={src} {...p} />
   )
 }
 


### PR DESCRIPTION
- chore: Update demo page
- fix: Regroup bundle items
- feat: Add new prop placeholder and set placeholder image if src is empty
