### PR TITLE
fix: Reset shipping method selector

### DIFF
--- a/src/components/OrderContainer.tsx
+++ b/src/components/OrderContainer.tsx
@@ -20,7 +20,7 @@ import orderReducer, {
 } from '#reducers/OrderReducer'
 import CommerceLayerContext from '#context/CommerceLayerContext'
 import OrderContext, { defaultOrderContext } from '#context/OrderContext'
-import { unsetOrderState, ResourceIncluded } from '#reducers/OrderReducer'
+import { ResourceIncluded } from '#reducers/OrderReducer'
 import components from '#config/components'
 import { BaseMetadataObject } from '#typings'
 import OrderStorageContext from '#context/OrderStorageContext'

--- a/src/components/Shipment.tsx
+++ b/src/components/Shipment.tsx
@@ -12,7 +12,7 @@ const displayName = components.Shipment.displayName
 type ShipmentProps = {
   children: ReactNode
   loader?: LoaderType
-  autoSelectSingleShippingMethod?: boolean
+  autoSelectSingleShippingMethod?: boolean | (() => void)
 }
 
 export default function Shipment({
@@ -31,6 +31,9 @@ export default function Shipment({
         if (!shipment?.shipping_method && isSingle) {
           const [shippingMethod] = shipment?.available_shipping_methods || []
           setShippingMethod(shipment?.id, shippingMethod?.id)
+          if (typeof autoSelectSingleShippingMethod === 'function') {
+            autoSelectSingleShippingMethod()
+          }
         }
       })
     }

--- a/src/components/ShipmentsContainer.tsx
+++ b/src/components/ShipmentsContainer.tsx
@@ -108,7 +108,7 @@ const ShipmentsContainer: React.FunctionComponent<ShipmentsContainerProps> = (
     return () => {
       setShipmentErrors([], dispatch)
     }
-  }, [order])
+  }, [order?.shipments])
   const contextValue = {
     ...state,
     setShipmentErrors: (errors: BaseError[]) =>

--- a/src/components/ShippingMethodRadioButton.tsx
+++ b/src/components/ShippingMethodRadioButton.tsx
@@ -1,4 +1,10 @@
-import { useContext, FunctionComponent, ReactNode, useEffect } from 'react'
+import {
+  useContext,
+  FunctionComponent,
+  ReactNode,
+  useEffect,
+  useState,
+} from 'react'
 import ShippingMethodChildrenContext from '#context/ShippingMethodChildrenContext'
 import Parent from './utils/Parent'
 import components from '#config/components'
@@ -27,6 +33,7 @@ const ShippingMethodRadioButton: FunctionComponent<
   ShippingMethodRadioButtonProps
 > = (props) => {
   const { onChange, ...p } = props
+  const [checked, setChecked] = useState(false)
   const { shippingMethod, currentShippingMethodId, shipmentId } = useContext(
     ShippingMethodChildrenContext
   )
@@ -34,12 +41,23 @@ const ShippingMethodRadioButton: FunctionComponent<
   const shippingMethodId = shippingMethod?.id
   const name = `shipment-${shipmentId}`
   const id = `${name}-${shippingMethodId}`
-  const checked = shippingMethodId === currentShippingMethodId
+  // const checked = shippingMethodId === currentShippingMethodId
+  useEffect(() => {
+    if (shippingMethodId === currentShippingMethodId) {
+      setChecked(true)
+    } else setChecked(false)
+    return () => {
+      setChecked(false)
+    }
+  }, [currentShippingMethodId])
+
   const handleOnChange = async () => {
     if (shipmentId) {
-      if (shippingMethodId)
+      if (shippingMethodId) {
+        setChecked(true)
         await setShippingMethod(shipmentId, shippingMethodId)
-      if (shippingMethod && onChange) onChange(shippingMethod, shipmentId)
+        if (shippingMethod && onChange) onChange(shippingMethod, shipmentId)
+      }
     }
   }
   const parentProps = {
@@ -58,7 +76,7 @@ const ShippingMethodRadioButton: FunctionComponent<
       name={name}
       id={id}
       onChange={handleOnChange}
-      defaultChecked={checked}
+      checked={checked}
       {...p}
     />
   )


### PR DESCRIPTION
- fix: Reset shipping method selector when add or remove a coupon
- perf: `autoSelectSingleShippingMethod` accept even a function
