### PR TITLE
Add payment_gateway in the PaymentMethodName children fn props

### DIFF
--- a/packages/react-components/src/components/payment_methods/PaymentMethodName.tsx
+++ b/packages/react-components/src/components/payment_methods/PaymentMethodName.tsx
@@ -20,11 +20,11 @@ export function PaymentMethodName(props: Props): JSX.Element {
   })
   const labelName = payment?.name
   const htmlFor = payment?.payment_source_type
-  const paymentReference = payment?.payment_gateway?.reference
+  const paymentGateway = payment?.payment_gateway
   const parentProps = {
     htmlFor,
     labelName,
-    paymentReference,
+    paymentGateway,
     ...props
   }
   return props.children ? (

--- a/packages/react-components/src/components/payment_methods/PaymentMethodName.tsx
+++ b/packages/react-components/src/components/payment_methods/PaymentMethodName.tsx
@@ -20,9 +20,11 @@ export function PaymentMethodName(props: Props): JSX.Element {
   })
   const labelName = payment?.name
   const htmlFor = payment?.payment_source_type
+  const paymentReference = payment?.payment_gateway?.reference
   const parentProps = {
     htmlFor,
     labelName,
+    paymentReference,
     ...props
   }
   return props.children ? (


### PR DESCRIPTION
### What does this PR do?
Add payment method reference to `PaymentMethodName` so it would be easier to distinguish different payment methods with the same source type.

Scenario example:
A commerce has 2 wire_transfers methods one for cash flow one for wire_transfer, right now it won't be able to distinguish them. 

### How should this be manually tested?
```
<PaymentMethodName>
      {({ labelName, htmlFor, paymentReference, ...props }) => {
        console.log(paymentReference)
        return (
          <label htmlFor={htmlFor}>{label}</label>
        )
      }}
    </PaymentMethodName>
```