### PR TITLE
Prevent empty list of orders or subscriptions to break the rendering

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.7.1",
+  "version": "4.7.2-beta.0",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.7.1",
+  "version": "4.7.2-beta.0",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/src/components/orders/OrderList.tsx
+++ b/packages/react-components/src/components/orders/OrderList.tsx
@@ -279,7 +279,7 @@ export function OrderList({
   if (loading && (orders == null || subscriptions == null)) {
     return <>{LoadingComponent}</>
   }
-  return orders?.length === 0 || subscriptions?.length === 0 ? (
+  return (type === 'orders' ? orders : subscriptions)?.length === 0 ? (
     <OrderListChildrenContext.Provider
       value={{ orders: type === 'orders' ? orders : subscriptions }}
     >


### PR DESCRIPTION
Closes #435

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've fixed the condition used to check if empty content needs to be rendered. 

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
