### PR TITLE
Restore `OrderList`'s columns classnames

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.7.3",
+  "version": "4.7.4-beta.0",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.7.3",
+  "version": "4.7.4-beta.0",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/src/components/orders/OrderList.tsx
+++ b/packages/react-components/src/components/orders/OrderList.tsx
@@ -198,7 +198,7 @@ export function OrderList({
   }, [orders, subscriptions])
   const LoadingComponent = loadingElement || <div>Loading...</div>
   const headerComponent = table.getHeaderGroups().map((headerGroup) => {
-    const columns = headerGroup.headers.map((header, k) => {
+    const columnsComponents = headerGroup.headers.map((header, k) => {
       const sortLabel =
         header.column.getIsSorted() !== false ? header.column.getIsSorted() : ''
       return (
@@ -206,12 +206,13 @@ export function OrderList({
           data-testid={`thead-${k}`}
           data-sort={`${sortLabel || ''}`}
           key={header.id}
+          className={columns[k]?.className}
         >
           <span
             {...{
-              className: header.column.getCanSort()
-                ? 'cursor-pointer select-none'
-                : '',
+              className: `${columns[k]?.titleClassName ?? ''} ${
+                header.column.getCanSort() ? 'cursor-pointer select-none' : ''
+              }`,
               onClick: header.column.getToggleSortingHandler()
             }}
           >
@@ -224,7 +225,9 @@ export function OrderList({
         </ThHtmlElement>
       )
     })
-    return <TrHtmlElement key={headerGroup.id}>{columns}</TrHtmlElement>
+    return (
+      <TrHtmlElement key={headerGroup.id}>{columnsComponents}</TrHtmlElement>
+    )
   })
   const rowsComponents = filterChildren({
     children,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I restored the usage of columns defined `className` and `titleClassNames` props that probably got lost during order subscriptions refactoring of `OrderList` component.

These props are actually used in `my-account` app to define the styling of `OrderList` heading columns.

Example:
```JSX

const colClassName = "text-left text-xs font-thin border-b border-gray-200 md:border-none text-gray-300 md:font-semibold md:uppercase md:relative"
const titleClassName = "flex gap-2"
const columns = [
    {
      header: "Order",
      accessorKey: "number",
      className: colClassName,
      titleClassName,
    },
    {
      header: "Date",
      accessorKey: "placed_at",
      className: colClassName,
      titleClassName,
    },
    {
      header: "Status",
      accessorKey: "status",
      className: colClassName,
      titleClassName,
    },
    {
      header: "Amount",
      accessorKey: "formatted_total_amount_with_taxes",
      className: colClassName,
      titleClassName,
    },
  ]

return (
    <>
        <OrderList
          className="w-full mb-8 table-fixed md:-mx-0"
          columns={columns}
          showActions={true}
          loadingElement={
            <div className="px-5 lg:p-0">
              <SkeletonMainOrdersTable />
            </div>
          }
          actionsContainerClassName="absolute right-1 order-5 align-top hidden md:relative md:align-middle py-5 text-center"
          theadClassName="hidden md:table-row-group"
          rowTrClassName="flex justify-between items-center relative md:content-center bg-white shadow-bottom mb-4 pb-12 md:pb-0 px-5 md:p-0 md:border-b md:border-gray-300 md:table-row md:shadow-none h-[107px] md:h-[96px]"
          showPagination
          pageSize={15}
          paginationContainerClassName="flex justify-between items-center"
        >
        ...
        </OrderList>
    </>
)

```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
