### PR TITLE
Allow line_items update using external_price

### DIFF
--- a/packages/react-components/src/components/line_items/LineItemQuantity.tsx
+++ b/packages/react-components/src/components/line_items/LineItemQuantity.tsx
@@ -16,11 +16,16 @@ type Props = {
   max?: number
   disabled?: boolean
   readonly?: boolean
+  /**
+   * force the update of the line item price using `_external_price: true` attribute
+   * @link https://docs.commercelayer.io/core/external-resources/external-prices
+   */
+  hasExternalPrice?: boolean
 } & (Omit<JSX.IntrinsicElements['select'], 'children'> &
   Omit<JSX.IntrinsicElements['span'], 'children'>)
 
 export function LineItemQuantity(props: Props): JSX.Element {
-  const { max = 50, readonly = false, ...p } = props
+  const { max = 50, readonly = false, hasExternalPrice, ...p } = props
   const { lineItem } = useContext(LineItemChildrenContext)
   const { updateLineItem } = useContext(LineItemContext)
   const options: ReactNode[] = []
@@ -33,7 +38,9 @@ export function LineItemQuantity(props: Props): JSX.Element {
   }
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     const quantity = Number(e.target.value)
-    if (updateLineItem && lineItem) void updateLineItem(lineItem.id, quantity)
+    if (updateLineItem && lineItem) {
+      void updateLineItem(lineItem.id, quantity, hasExternalPrice)
+    }
   }
   const quantity = lineItem?.quantity
   const parentProps = {

--- a/packages/react-components/src/components/line_items/LineItemsContainer.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsContainer.tsx
@@ -65,10 +65,11 @@ export function LineItemsContainer(props: Props): JSX.Element {
   const lineItemValue: LineItemContextValue = {
     ...state,
     loader,
-    updateLineItem: async (lineItemId, quantity = 1) => {
+    updateLineItem: async (lineItemId, quantity = 1, hasExternalPrice) => {
       await updateLineItem({
         lineItemId,
         quantity,
+        hasExternalPrice,
         dispatch,
         config,
         getOrder,

--- a/packages/react-components/src/reducers/LineItemReducer.ts
+++ b/packages/react-components/src/reducers/LineItemReducer.ts
@@ -11,6 +11,7 @@ import getErrors from '#utils/getErrors'
 export interface UpdateLineItemParams {
   lineItemId: string
   quantity?: number
+  hasExternalPrice?: boolean
   dispatch: Dispatch<LineItemAction>
   config: CommerceLayerConfig
   getOrder: getOrderContext | undefined
@@ -41,7 +42,11 @@ export interface LineItemPayload {
 }
 
 export interface LineItemState extends LineItemPayload {
-  updateLineItem?: (lineItemId: string, quantity?: number) => Promise<void>
+  updateLineItem?: (
+    lineItemId: string,
+    quantity?: number,
+    hasExternalPrice?: boolean
+  ) => Promise<void>
   deleteLineItem?: (lineItemId: string) => Promise<void>
 }
 
@@ -95,10 +100,22 @@ export const getLineItems: GetLineItems = (params) => {
 export async function updateLineItem(
   params: UpdateLineItemParams
 ): Promise<void> {
-  const { config, lineItemId, quantity, getOrder, orderId, dispatch } = params
+  const {
+    config,
+    lineItemId,
+    quantity,
+    hasExternalPrice,
+    getOrder,
+    orderId,
+    dispatch
+  } = params
   const sdk = getSdk(config)
   try {
-    await sdk.line_items.update({ id: lineItemId, quantity })
+    await sdk.line_items.update({
+      id: lineItemId,
+      quantity,
+      _external_price: hasExternalPrice
+    })
     getOrder && (await getOrder(orderId))
     dispatch({
       type: 'setErrors',


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

When we have a `line_item` we don't know if has been created with an external price, since `_external_price` is a trigger attribute and nothing is saved at the item level.

What happens now is that when we update a quantity with the `<LineItemQuantity>` component the PATCH request updates the price using the regular price list.

With this PR we are exposing a `hasExternalPrice` prop to `<LineItemQuantity>` so that the consumer app can instruct it to patch the `line_item` using `_external_price: true`.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
