### PR TITLE
Add ability to override Country list or to extends pre-defined list of States 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.7.8",
+  "version": "4.7.9-beta.0",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.7.8",
+  "version": "4.7.9-beta.0",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -178,8 +178,6 @@
   },
   "homepage": "https://github.com/commercelayer/commercelayer-react-components#readme",
   "dependencies": {
-    "@ac-dev/countries-service": "^1.2.0",
-    "@ac-dev/states-service": "^1.1.1",
     "@adyen/adyen-web": "^5.51.0",
     "@commercelayer/sdk": "^5.14.0",
     "@stripe/react-stripe-js": "^2.3.0",

--- a/packages/react-components/src/components/addresses/AddressCountrySelector.tsx
+++ b/packages/react-components/src/components/addresses/AddressCountrySelector.tsx
@@ -5,7 +5,7 @@ import BillingAddressFormContext, {
   type AddressValuesKeys
 } from '#context/BillingAddressFormContext'
 import ShippingAddressFormContext from '#context/ShippingAddressFormContext'
-import { getCountries } from '#utils/countryStateCity'
+import { getCountries, type Country } from '#utils/countryStateCity'
 import CustomerAddressFormContext from '#context/CustomerAddressFormContext'
 
 type TCountryFieldName =
@@ -19,10 +19,14 @@ interface Props
   name: Extract<AddressValuesKeys, TCountryFieldName>
   required?: boolean
   disabled?: boolean
+  /**
+   * Optional country list to override default ones.
+   */
+  countries?: Country[]
 }
 
 export function AddressCountrySelector(props: Props): JSX.Element {
-  const { required = true, value, name, className, ...p } = props
+  const { required = true, value, name, className, countries, ...p } = props
   const billingAddress = useContext(BillingAddressFormContext)
   const shippingAddress = useContext(ShippingAddressFormContext)
   const customerAddress = useContext(CustomerAddressFormContext)
@@ -71,7 +75,7 @@ export function AddressCountrySelector(props: Props): JSX.Element {
         customerAddress?.validation
       }
       required={required}
-      options={getCountries()}
+      options={getCountries(countries)}
       name={name}
       value={value}
       {...p}

--- a/packages/react-components/src/components/customers/CustomerAddressForm.tsx
+++ b/packages/react-components/src/components/customers/CustomerAddressForm.tsx
@@ -6,13 +6,18 @@ import { type BaseError, type CodeErrorType } from '#typings/errors'
 import { type AddressField } from '#reducers/AddressReducer'
 import { type AddressCountrySelectName, type AddressInputName } from '#typings'
 import OrderContext from '#context/OrderContext'
-import isEmptyStates from '#utils/isEmptyStates'
+import { isEmptyStates } from '#utils/countryStateCity'
 import type { Address } from '@commercelayer/sdk'
 
 interface Props extends Omit<JSX.IntrinsicElements['form'], 'onSubmit'> {
   children: ReactNode
   reset?: boolean
   errorClassName?: string
+  /**
+   * Array of countries that have states has select options. Ignore this if you are not overriding the default states list.
+   * If you are overriding the default states list, you must pass the countries that have states as select options.
+   */
+  countriesWithPredefinedStateOptions?: string[]
 }
 
 export function CustomerAddressForm(props: Props): JSX.Element {
@@ -21,6 +26,7 @@ export function CustomerAddressForm(props: Props): JSX.Element {
     errorClassName,
     autoComplete = 'on',
     reset = false,
+    countriesWithPredefinedStateOptions,
     ...p
   } = props
   const { validation, values, errors, reset: resetForm } = useRapidForm()
@@ -67,7 +73,13 @@ export function CustomerAddressForm(props: Props): JSX.Element {
         if (['billing_address_state_code'].includes(name)) {
           const countryCode = (values['billing_address_country_code']?.value ||
             values['country_code']) as string
-          if (!isEmptyStates(countryCode) && !field.value) {
+          if (
+            !isEmptyStates({
+              countryCode,
+              countriesWithPredefinedStateOptions
+            }) &&
+            !field.value
+          ) {
             // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
             delete values['billing_address_state_code']
           }

--- a/packages/react-components/src/utils/countryStateCity.ts
+++ b/packages/react-components/src/utils/countryStateCity.ts
@@ -1,40 +1,1761 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import { Countries } from '@ac-dev/countries-service'
-import { States } from '@ac-dev/states-service'
-type ReturnStates = Array<{
+import isEmpty from 'lodash/isEmpty'
+
+/**
+ * Validate the list of countries the user can optionally pass or returns our default list
+ * @param countries - Optional list of countries to override default ones
+ * @returns List of countries
+ */
+export function getCountries(countries?: Country[]): Country[] {
+  if (
+    !isEmpty(countries) &&
+    countries?.every((c) => 'value' in c && 'label' in c)
+  ) {
+    return countries
+  }
+  return [...defaultCountries]
+}
+
+/**
+ * Get the list of states for a given country, if the user pass a list of states we use that one
+ * otherwise we use our default list.
+ * If no states are found for the given country we return an empty array.
+ * @param countryCode - code of selected country (e.g. IT)
+ * @param states - Optional list of states to override our default list
+ * @returns List of states for the selected country or empty array
+ */
+export function getStateOfCountry({
+  countryCode,
+  states
+}: {
+  countryCode: string
+  states?: States
+}): State[] {
+  const statesToUse = {
+    ...defaultStates,
+    ...states
+  }
+  return statesToUse[countryCode as CountryCode] ?? []
+}
+
+/**
+ * Check if the given state is valid for the given country.
+ * If the user is overriding our default states list, it must be passed as option.
+ * @param stateCode - code of selected state
+ * @param countryCode - code of selected country
+ * @param states - Optional list of states to override our default list
+ * @returns Boolean - true if the state is valid for the given country
+ */
+export function isValidState({
+  stateCode,
+  countryCode,
+  states
+}: {
+  stateCode: string
+  countryCode: string
+  states?: States
+}): boolean {
+  const statesToUse = {
+    ...defaultStates,
+    ...states
+  }
+  return Boolean(
+    statesToUse[countryCode as CountryCode]?.find(
+      (state) => state.value === stateCode
+    )
+  )
+}
+
+/**
+ * Check if the given country has a pre-defined list of states as select options.
+ * If the user is overriding our default states list, it must be specified by passing an array of countries as option.
+ */
+export function isEmptyStates({
+  countryCode,
+  countriesWithPredefinedStateOptions
+}: {
+  countryCode: string
+  countriesWithPredefinedStateOptions?: string[]
+}): boolean {
+  const countryLock =
+    countriesWithPredefinedStateOptions == null ||
+    isEmpty(countriesWithPredefinedStateOptions)
+      ? Object.keys(defaultStates)
+      : countriesWithPredefinedStateOptions
+  return !countryLock.includes(countryCode)
+}
+
+const defaultCountries = [
+  {
+    label: 'Afghanistan',
+    value: 'AF'
+  },
+  {
+    label: 'Aland Islands',
+    value: 'AX'
+  },
+  {
+    label: 'Albania',
+    value: 'AL'
+  },
+  {
+    label: 'Algeria',
+    value: 'DZ'
+  },
+  {
+    label: 'American Samoa',
+    value: 'AS'
+  },
+  {
+    label: 'Andorra',
+    value: 'AD'
+  },
+  {
+    label: 'Angola',
+    value: 'AO'
+  },
+  {
+    label: 'Anguilla',
+    value: 'AI'
+  },
+  {
+    label: 'Antarctica',
+    value: 'AQ'
+  },
+  {
+    label: 'Antigua And Barbuda',
+    value: 'AG'
+  },
+  {
+    label: 'Argentina',
+    value: 'AR'
+  },
+  {
+    label: 'Armenia',
+    value: 'AM'
+  },
+  {
+    label: 'Aruba',
+    value: 'AW'
+  },
+  {
+    label: 'Australia',
+    value: 'AU'
+  },
+  {
+    label: 'Austria',
+    value: 'AT'
+  },
+  {
+    label: 'Azerbaijan',
+    value: 'AZ'
+  },
+  {
+    label: 'Bahamas The',
+    value: 'BS'
+  },
+  {
+    label: 'Bahrain',
+    value: 'BH'
+  },
+  {
+    label: 'Bangladesh',
+    value: 'BD'
+  },
+  {
+    label: 'Barbados',
+    value: 'BB'
+  },
+  {
+    label: 'Belarus',
+    value: 'BY'
+  },
+  {
+    label: 'Belgium',
+    value: 'BE'
+  },
+  {
+    label: 'Belize',
+    value: 'BZ'
+  },
+  {
+    label: 'Benin',
+    value: 'BJ'
+  },
+  {
+    label: 'Bermuda',
+    value: 'BM'
+  },
+  {
+    label: 'Bhutan',
+    value: 'BT'
+  },
+  {
+    label: 'Bolivia',
+    value: 'BO'
+  },
+  {
+    label: 'Bonaire, Sint Eustatius and Saba',
+    value: 'BQ'
+  },
+  {
+    label: 'Bosnia and Herzegovina',
+    value: 'BA'
+  },
+  {
+    label: 'Botswana',
+    value: 'BW'
+  },
+  {
+    label: 'Bouvet Island',
+    value: 'BV'
+  },
+  {
+    label: 'Brazil',
+    value: 'BR'
+  },
+  {
+    label: 'British Indian Ocean Territory',
+    value: 'IO'
+  },
+  {
+    label: 'Brunei',
+    value: 'BN'
+  },
+  {
+    label: 'Bulgaria',
+    value: 'BG'
+  },
+  {
+    label: 'Burkina Faso',
+    value: 'BF'
+  },
+  {
+    label: 'Burundi',
+    value: 'BI'
+  },
+  {
+    label: 'Cambodia',
+    value: 'KH'
+  },
+  {
+    label: 'Cameroon',
+    value: 'CM'
+  },
+  {
+    label: 'Canada',
+    value: 'CA'
+  },
+  {
+    label: 'Cape Verde',
+    value: 'CV'
+  },
+  {
+    label: 'Cayman Islands',
+    value: 'KY'
+  },
+  {
+    label: 'Central African Republic',
+    value: 'CF'
+  },
+  {
+    label: 'Chad',
+    value: 'TD'
+  },
+  {
+    label: 'Chile',
+    value: 'CL'
+  },
+  {
+    label: 'China',
+    value: 'CN'
+  },
+  {
+    label: 'Christmas Island',
+    value: 'CX'
+  },
+  {
+    label: 'Cocos (Keeling) Islands',
+    value: 'CC'
+  },
+  {
+    label: 'Colombia',
+    value: 'CO'
+  },
+  {
+    label: 'Comoros',
+    value: 'KM'
+  },
+  {
+    label: 'Congo',
+    value: 'CG'
+  },
+  {
+    label: 'Cook Islands',
+    value: 'CK'
+  },
+  {
+    label: 'Costa Rica',
+    value: 'CR'
+  },
+  {
+    label: "Cote D'Ivoire (Ivory Coast)",
+    value: 'CI'
+  },
+  {
+    label: 'Croatia',
+    value: 'HR'
+  },
+  {
+    label: 'Cuba',
+    value: 'CU'
+  },
+  {
+    label: 'Curaçao',
+    value: 'CW'
+  },
+  {
+    label: 'Cyprus',
+    value: 'CY'
+  },
+  {
+    label: 'Czech Republic',
+    value: 'CZ'
+  },
+  {
+    label: 'Democratic Republic of the Congo',
+    value: 'CD'
+  },
+  {
+    label: 'Denmark',
+    value: 'DK'
+  },
+  {
+    label: 'Djibouti',
+    value: 'DJ'
+  },
+  {
+    label: 'Dominica',
+    value: 'DM'
+  },
+  {
+    label: 'Dominican Republic',
+    value: 'DO'
+  },
+  {
+    label: 'East Timor',
+    value: 'TL'
+  },
+  {
+    label: 'Ecuador',
+    value: 'EC'
+  },
+  {
+    label: 'Egypt',
+    value: 'EG'
+  },
+  {
+    label: 'El Salvador',
+    value: 'SV'
+  },
+  {
+    label: 'Equatorial Guinea',
+    value: 'GQ'
+  },
+  {
+    label: 'Eritrea',
+    value: 'ER'
+  },
+  {
+    label: 'Estonia',
+    value: 'EE'
+  },
+  {
+    label: 'Ethiopia',
+    value: 'ET'
+  },
+  {
+    label: 'Falkland Islands',
+    value: 'FK'
+  },
+  {
+    label: 'Faroe Islands',
+    value: 'FO'
+  },
+  {
+    label: 'Fiji Islands',
+    value: 'FJ'
+  },
+  {
+    label: 'Finland',
+    value: 'FI'
+  },
+  {
+    label: 'France',
+    value: 'FR'
+  },
+  {
+    label: 'French Guiana',
+    value: 'GF'
+  },
+  {
+    label: 'French Polynesia',
+    value: 'PF'
+  },
+  {
+    label: 'French Southern Territories',
+    value: 'TF'
+  },
+  {
+    label: 'Gabon',
+    value: 'GA'
+  },
+  {
+    label: 'Gambia The',
+    value: 'GM'
+  },
+  {
+    label: 'Georgia',
+    value: 'GE'
+  },
+  {
+    label: 'Germany',
+    value: 'DE'
+  },
+  {
+    label: 'Ghana',
+    value: 'GH'
+  },
+  {
+    label: 'Gibraltar',
+    value: 'GI'
+  },
+  {
+    label: 'Greece',
+    value: 'GR'
+  },
+  {
+    label: 'Greenland',
+    value: 'GL'
+  },
+  {
+    label: 'Grenada',
+    value: 'GD'
+  },
+  {
+    label: 'Guadeloupe',
+    value: 'GP'
+  },
+  {
+    label: 'Guam',
+    value: 'GU'
+  },
+  {
+    label: 'Guatemala',
+    value: 'GT'
+  },
+  {
+    label: 'Guernsey and Alderney',
+    value: 'GG'
+  },
+  {
+    label: 'Guinea',
+    value: 'GN'
+  },
+  {
+    label: 'Guinea-Bissau',
+    value: 'GW'
+  },
+  {
+    label: 'Guyana',
+    value: 'GY'
+  },
+  {
+    label: 'Haiti',
+    value: 'HT'
+  },
+  {
+    label: 'Heard Island and McDonald Islands',
+    value: 'HM'
+  },
+  {
+    label: 'Honduras',
+    value: 'HN'
+  },
+  {
+    label: 'Hong Kong S.A.R.',
+    value: 'HK'
+  },
+  {
+    label: 'Hungary',
+    value: 'HU'
+  },
+  {
+    label: 'Iceland',
+    value: 'IS'
+  },
+  {
+    label: 'India',
+    value: 'IN'
+  },
+  {
+    label: 'Indonesia',
+    value: 'ID'
+  },
+  {
+    label: 'Iran',
+    value: 'IR'
+  },
+  {
+    label: 'Iraq',
+    value: 'IQ'
+  },
+  {
+    label: 'Ireland',
+    value: 'IE'
+  },
+  {
+    label: 'Israel',
+    value: 'IL'
+  },
+  {
+    label: 'Italy',
+    value: 'IT'
+  },
+  {
+    label: 'Jamaica',
+    value: 'JM'
+  },
+  {
+    label: 'Japan',
+    value: 'JP'
+  },
+  {
+    label: 'Jersey',
+    value: 'JE'
+  },
+  {
+    label: 'Jordan',
+    value: 'JO'
+  },
+  {
+    label: 'Kazakhstan',
+    value: 'KZ'
+  },
+  {
+    label: 'Kenya',
+    value: 'KE'
+  },
+  {
+    label: 'Kiribati',
+    value: 'KI'
+  },
+  {
+    label: 'Kosovo',
+    value: 'XK'
+  },
+  {
+    label: 'Kuwait',
+    value: 'KW'
+  },
+  {
+    label: 'Kyrgyzstan',
+    value: 'KG'
+  },
+  {
+    label: 'Laos',
+    value: 'LA'
+  },
+  {
+    label: 'Latvia',
+    value: 'LV'
+  },
+  {
+    label: 'Lebanon',
+    value: 'LB'
+  },
+  {
+    label: 'Lesotho',
+    value: 'LS'
+  },
+  {
+    label: 'Liberia',
+    value: 'LR'
+  },
+  {
+    label: 'Libya',
+    value: 'LY'
+  },
+  {
+    label: 'Liechtenstein',
+    value: 'LI'
+  },
+  {
+    label: 'Lithuania',
+    value: 'LT'
+  },
+  {
+    label: 'Luxembourg',
+    value: 'LU'
+  },
+  {
+    label: 'Macau S.A.R.',
+    value: 'MO'
+  },
+  {
+    label: 'Macedonia',
+    value: 'MK'
+  },
+  {
+    label: 'Madagascar',
+    value: 'MG'
+  },
+  {
+    label: 'Malawi',
+    value: 'MW'
+  },
+  {
+    label: 'Malaysia',
+    value: 'MY'
+  },
+  {
+    label: 'Maldives',
+    value: 'MV'
+  },
+  {
+    label: 'Mali',
+    value: 'ML'
+  },
+  {
+    label: 'Malta',
+    value: 'MT'
+  },
+  {
+    label: 'Man (Isle of)',
+    value: 'IM'
+  },
+  {
+    label: 'Marshall Islands',
+    value: 'MH'
+  },
+  {
+    label: 'Martinique',
+    value: 'MQ'
+  },
+  {
+    label: 'Mauritania',
+    value: 'MR'
+  },
+  {
+    label: 'Mauritius',
+    value: 'MU'
+  },
+  {
+    label: 'Mayotte',
+    value: 'YT'
+  },
+  {
+    label: 'Mexico',
+    value: 'MX'
+  },
+  {
+    label: 'Micronesia',
+    value: 'FM'
+  },
+  {
+    label: 'Moldova',
+    value: 'MD'
+  },
+  {
+    label: 'Monaco',
+    value: 'MC'
+  },
+  {
+    label: 'Mongolia',
+    value: 'MN'
+  },
+  {
+    label: 'Montenegro',
+    value: 'ME'
+  },
+  {
+    label: 'Montserrat',
+    value: 'MS'
+  },
+  {
+    label: 'Morocco',
+    value: 'MA'
+  },
+  {
+    label: 'Mozambique',
+    value: 'MZ'
+  },
+  {
+    label: 'Myanmar',
+    value: 'MM'
+  },
+  {
+    label: 'Namibia',
+    value: 'NA'
+  },
+  {
+    label: 'Nauru',
+    value: 'NR'
+  },
+  {
+    label: 'Nepal',
+    value: 'NP'
+  },
+  {
+    label: 'Netherlands',
+    value: 'NL'
+  },
+  {
+    label: 'New Caledonia',
+    value: 'NC'
+  },
+  {
+    label: 'New Zealand',
+    value: 'NZ'
+  },
+  {
+    label: 'Nicaragua',
+    value: 'NI'
+  },
+  {
+    label: 'Niger',
+    value: 'NE'
+  },
+  {
+    label: 'Nigeria',
+    value: 'NG'
+  },
+  {
+    label: 'Niue',
+    value: 'NU'
+  },
+  {
+    label: 'Norfolk Island',
+    value: 'NF'
+  },
+  {
+    label: 'North Korea',
+    value: 'KP'
+  },
+  {
+    label: 'Northern Mariana Islands',
+    value: 'MP'
+  },
+  {
+    label: 'Norway',
+    value: 'NO'
+  },
+  {
+    label: 'Oman',
+    value: 'OM'
+  },
+  {
+    label: 'Pakistan',
+    value: 'PK'
+  },
+  {
+    label: 'Palau',
+    value: 'PW'
+  },
+  {
+    label: 'Palestinian Territory Occupied',
+    value: 'PS'
+  },
+  {
+    label: 'Panama',
+    value: 'PA'
+  },
+  {
+    label: 'Papua new Guinea',
+    value: 'PG'
+  },
+  {
+    label: 'Paraguay',
+    value: 'PY'
+  },
+  {
+    label: 'Peru',
+    value: 'PE'
+  },
+  {
+    label: 'Philippines',
+    value: 'PH'
+  },
+  {
+    label: 'Pitcairn Island',
+    value: 'PN'
+  },
+  {
+    label: 'Poland',
+    value: 'PL'
+  },
+  {
+    label: 'Portugal',
+    value: 'PT'
+  },
+  {
+    label: 'Puerto Rico',
+    value: 'PR'
+  },
+  {
+    label: 'Qatar',
+    value: 'QA'
+  },
+  {
+    label: 'Reunion',
+    value: 'RE'
+  },
+  {
+    label: 'Romania',
+    value: 'RO'
+  },
+  {
+    label: 'Russia',
+    value: 'RU'
+  },
+  {
+    label: 'Rwanda',
+    value: 'RW'
+  },
+  {
+    label: 'Saint Helena',
+    value: 'SH'
+  },
+  {
+    label: 'Saint Kitts And Nevis',
+    value: 'KN'
+  },
+  {
+    label: 'Saint Lucia',
+    value: 'LC'
+  },
+  {
+    label: 'Saint Pierre and Miquelon',
+    value: 'PM'
+  },
+  {
+    label: 'Saint Vincent And The Grenadines',
+    value: 'VC'
+  },
+  {
+    label: 'Saint-Barthelemy',
+    value: 'BL'
+  },
+  {
+    label: 'Saint-Martin (French part)',
+    value: 'MF'
+  },
+  {
+    label: 'Samoa',
+    value: 'WS'
+  },
+  {
+    label: 'San Marino',
+    value: 'SM'
+  },
+  {
+    label: 'Sao Tome and Principe',
+    value: 'ST'
+  },
+  {
+    label: 'Saudi Arabia',
+    value: 'SA'
+  },
+  {
+    label: 'Senegal',
+    value: 'SN'
+  },
+  {
+    label: 'Serbia',
+    value: 'RS'
+  },
+  {
+    label: 'Seychelles',
+    value: 'SC'
+  },
+  {
+    label: 'Sierra Leone',
+    value: 'SL'
+  },
+  {
+    label: 'Singapore',
+    value: 'SG'
+  },
+  {
+    label: 'Sint Maarten (Dutch part)',
+    value: 'SX'
+  },
+  {
+    label: 'Slovakia',
+    value: 'SK'
+  },
+  {
+    label: 'Slovenia',
+    value: 'SI'
+  },
+  {
+    label: 'Solomon Islands',
+    value: 'SB'
+  },
+  {
+    label: 'Somalia',
+    value: 'SO'
+  },
+  {
+    label: 'South Africa',
+    value: 'ZA'
+  },
+  {
+    label: 'South Georgia',
+    value: 'GS'
+  },
+  {
+    label: 'South Korea',
+    value: 'KR'
+  },
+  {
+    label: 'South Sudan',
+    value: 'SS'
+  },
+  {
+    label: 'Spain',
+    value: 'ES'
+  },
+  {
+    label: 'Sri Lanka',
+    value: 'LK'
+  },
+  {
+    label: 'Sudan',
+    value: 'SD'
+  },
+  {
+    label: 'Suriname',
+    value: 'SR'
+  },
+  {
+    label: 'Svalbard And Jan Mayen Islands',
+    value: 'SJ'
+  },
+  {
+    label: 'Swaziland',
+    value: 'SZ'
+  },
+  {
+    label: 'Sweden',
+    value: 'SE'
+  },
+  {
+    label: 'Switzerland',
+    value: 'CH'
+  },
+  {
+    label: 'Syria',
+    value: 'SY'
+  },
+  {
+    label: 'Taiwan',
+    value: 'TW'
+  },
+  {
+    label: 'Tajikistan',
+    value: 'TJ'
+  },
+  {
+    label: 'Tanzania',
+    value: 'TZ'
+  },
+  {
+    label: 'Thailand',
+    value: 'TH'
+  },
+  {
+    label: 'Togo',
+    value: 'TG'
+  },
+  {
+    label: 'Tokelau',
+    value: 'TK'
+  },
+  {
+    label: 'Tonga',
+    value: 'TO'
+  },
+  {
+    label: 'Trinidad And Tobago',
+    value: 'TT'
+  },
+  {
+    label: 'Tunisia',
+    value: 'TN'
+  },
+  {
+    label: 'Turkey',
+    value: 'TR'
+  },
+  {
+    label: 'Turkmenistan',
+    value: 'TM'
+  },
+  {
+    label: 'Turks And Caicos Islands',
+    value: 'TC'
+  },
+  {
+    label: 'Tuvalu',
+    value: 'TV'
+  },
+  {
+    label: 'Uganda',
+    value: 'UG'
+  },
+  {
+    label: 'Ukraine',
+    value: 'UA'
+  },
+  {
+    label: 'United Arab Emirates',
+    value: 'AE'
+  },
+  {
+    label: 'United Kingdom',
+    value: 'GB'
+  },
+  {
+    label: 'United States',
+    value: 'US'
+  },
+  {
+    label: 'United States Minor Outlying Islands',
+    value: 'UM'
+  },
+  {
+    label: 'Uruguay',
+    value: 'UY'
+  },
+  {
+    label: 'Uzbekistan',
+    value: 'UZ'
+  },
+  {
+    label: 'Vanuatu',
+    value: 'VU'
+  },
+  {
+    label: 'Vatican City State (Holy See)',
+    value: 'VA'
+  },
+  {
+    label: 'Venezuela',
+    value: 'VE'
+  },
+  {
+    label: 'Vietnam',
+    value: 'VN'
+  },
+  {
+    label: 'Virgin Islands (British)',
+    value: 'VG'
+  },
+  {
+    label: 'Virgin Islands (US)',
+    value: 'VI'
+  },
+  {
+    label: 'Wallis And Futuna Islands',
+    value: 'WF'
+  },
+  {
+    label: 'Western Sahara',
+    value: 'EH'
+  },
+  {
+    label: 'Yemen',
+    value: 'YE'
+  },
+  {
+    label: 'Zambia',
+    value: 'ZM'
+  },
+  {
+    label: 'Zimbabwe',
+    value: 'ZW'
+  }
+] as const
+
+const statesIt: State[] = [
+  {
+    label: 'Agrigento',
+    value: 'AG'
+  },
+  {
+    label: 'Alessandria',
+    value: 'AL'
+  },
+  {
+    label: 'Ancona',
+    value: 'AN'
+  },
+  {
+    label: 'Aosta',
+    value: 'AO'
+  },
+  {
+    label: 'Arezzo',
+    value: 'AR'
+  },
+  {
+    label: 'Ascoli Piceno',
+    value: 'AP'
+  },
+  {
+    label: 'Asti',
+    value: 'AT'
+  },
+  {
+    label: 'Avellino',
+    value: 'AV'
+  },
+  {
+    label: 'Bari',
+    value: 'BA'
+  },
+  {
+    label: 'Barletta-Andria-Trani',
+    value: 'BT'
+  },
+  {
+    label: 'Belluno',
+    value: 'BL'
+  },
+  {
+    label: 'Benevento',
+    value: 'BN'
+  },
+  {
+    label: 'Bergamo',
+    value: 'BG'
+  },
+  {
+    label: 'Biella',
+    value: 'BI'
+  },
+  {
+    label: 'Bologna',
+    value: 'BO'
+  },
+  {
+    label: 'Bolzano',
+    value: 'BZ'
+  },
+  {
+    label: 'Brescia',
+    value: 'BS'
+  },
+  {
+    label: 'Brindisi',
+    value: 'BR'
+  },
+  {
+    label: 'Cagliari',
+    value: 'CA'
+  },
+  {
+    label: 'Caltanissetta',
+    value: 'CL'
+  },
+  {
+    label: 'Campobasso',
+    value: 'CB'
+  },
+  {
+    label: 'Carbonia-Iglesias',
+    value: 'CI'
+  },
+  {
+    label: 'Caserta',
+    value: 'CE'
+  },
+  {
+    label: 'Catania',
+    value: 'CT'
+  },
+  {
+    label: 'Catanzaro',
+    value: 'CZ'
+  },
+  {
+    label: 'Chieti',
+    value: 'CH'
+  },
+  {
+    label: 'Como',
+    value: 'CO'
+  },
+  {
+    label: 'Cosenza',
+    value: 'CS'
+  },
+  {
+    label: 'Cremona',
+    value: 'CR'
+  },
+  {
+    label: 'Crotone',
+    value: 'KR'
+  },
+  {
+    label: 'Cuneo',
+    value: 'CN'
+  },
+  {
+    label: 'Enna',
+    value: 'EN'
+  },
+  {
+    label: 'Fermo',
+    value: 'FM'
+  },
+  {
+    label: 'Ferrara',
+    value: 'FE'
+  },
+  {
+    label: 'Florence',
+    value: 'FI'
+  },
+  {
+    label: 'Foggia',
+    value: 'FG'
+  },
+  {
+    label: 'Forlì-Cesena',
+    value: 'FC'
+  },
+  {
+    label: 'Frosinone',
+    value: 'FR'
+  },
+  {
+    label: 'Genoa',
+    value: 'GE'
+  },
+  {
+    label: 'Gorizia',
+    value: 'GO'
+  },
+  {
+    label: 'Grosseto',
+    value: 'GR'
+  },
+  {
+    label: 'Imperia',
+    value: 'IM'
+  },
+  {
+    label: 'Isernia',
+    value: 'IS'
+  },
+  {
+    label: " L'Aquila",
+    value: 'AQ'
+  },
+  {
+    label: 'La Spezia',
+    value: 'SP'
+  },
+  {
+    label: 'Latina',
+    value: 'LT'
+  },
+  {
+    label: 'Lecce',
+    value: 'LE'
+  },
+  {
+    label: 'Lecco',
+    value: 'LC'
+  },
+  {
+    label: 'Livorno',
+    value: 'LI'
+  },
+  {
+    label: 'Lodi',
+    value: 'LO'
+  },
+  {
+    label: 'Lucca',
+    value: 'LU'
+  },
+  {
+    label: 'Macerata',
+    value: 'MC'
+  },
+  {
+    label: 'Mantua',
+    value: 'MN'
+  },
+  {
+    label: 'Massa and Carrara',
+    value: 'MS'
+  },
+  {
+    label: 'Matera',
+    value: 'MT'
+  },
+  {
+    label: 'Medio Campidano',
+    value: 'VS'
+  },
+  {
+    label: 'Messina',
+    value: 'ME'
+  },
+  {
+    label: 'Milan',
+    value: 'MI'
+  },
+  {
+    label: 'Modena',
+    value: 'MO'
+  },
+  {
+    label: 'Monza and Brianza',
+    value: 'MB'
+  },
+  {
+    label: 'Naples',
+    value: 'NA'
+  },
+  {
+    label: 'Novara',
+    value: 'NO'
+  },
+  {
+    label: 'Nuoro',
+    value: 'NU'
+  },
+  {
+    label: 'Ogliastra',
+    value: 'OG'
+  },
+  {
+    label: 'Olbia-Tempio',
+    value: 'OT'
+  },
+  {
+    label: 'Oristano',
+    value: 'OR'
+  },
+  {
+    label: 'Padua',
+    value: 'PD'
+  },
+  {
+    label: 'Palermo',
+    value: 'PA'
+  },
+  {
+    label: 'Parma',
+    value: 'PR'
+  },
+  {
+    label: 'Pavia',
+    value: 'PV'
+  },
+  {
+    label: 'Perugia',
+    value: 'PG'
+  },
+  {
+    label: 'Pesaro and Urbino',
+    value: 'PU'
+  },
+  {
+    label: 'Pescara',
+    value: 'PE'
+  },
+  {
+    label: 'Piacenza',
+    value: 'PC'
+  },
+  {
+    label: 'Pisa',
+    value: 'PI'
+  },
+  {
+    label: 'Pistoia',
+    value: 'PT'
+  },
+  {
+    label: 'Pordenone',
+    value: 'PN'
+  },
+  {
+    label: 'Potenza',
+    value: 'PZ'
+  },
+  {
+    label: 'Prato',
+    value: 'PO'
+  },
+  {
+    label: 'Ragusa',
+    value: 'RG'
+  },
+  {
+    label: 'Ravenna',
+    value: 'RA'
+  },
+  {
+    label: 'Reggio Calabria',
+    value: 'RC'
+  },
+  {
+    label: 'Reggio Emilia',
+    value: 'RE'
+  },
+  {
+    label: 'Rieti',
+    value: 'RI'
+  },
+  {
+    label: 'Rimini',
+    value: 'RN'
+  },
+  {
+    label: 'Rome',
+    value: 'RM'
+  },
+  {
+    label: 'Rovigo',
+    value: 'RO'
+  },
+  {
+    label: 'Salerno',
+    value: 'SA'
+  },
+  {
+    label: 'Sassari',
+    value: 'SS'
+  },
+  {
+    label: 'Savona',
+    value: 'SV'
+  },
+  {
+    label: 'Siena',
+    value: 'SI'
+  },
+  {
+    label: 'Sondrio',
+    value: 'SO'
+  },
+  {
+    label: 'South Sardinia',
+    value: 'SU'
+  },
+  {
+    label: 'Syracuse',
+    value: 'SR'
+  },
+  {
+    label: 'Taranto',
+    value: 'TA'
+  },
+  {
+    label: 'Teramo',
+    value: 'TE'
+  },
+  {
+    label: 'Terni',
+    value: 'TR'
+  },
+  {
+    label: 'Trapani',
+    value: 'TP'
+  },
+  {
+    label: 'Trento',
+    value: 'TN'
+  },
+  {
+    label: 'Treviso',
+    value: 'TV'
+  },
+  {
+    label: 'Trieste',
+    value: 'TS'
+  },
+  {
+    label: 'Turin',
+    value: 'TO'
+  },
+  {
+    label: 'Udine',
+    value: 'UD'
+  },
+  {
+    label: 'Varese',
+    value: 'VA'
+  },
+  {
+    label: 'Venice',
+    value: 'VE'
+  },
+  {
+    label: 'Verbano-Cusio-Ossola',
+    value: 'VB'
+  },
+  {
+    label: 'Vercelli',
+    value: 'VC'
+  },
+  {
+    label: 'Verona',
+    value: 'VR'
+  },
+  {
+    label: 'Vibo Valentia',
+    value: 'VV'
+  },
+  {
+    label: 'Vicenza',
+    value: 'VI'
+  },
+  {
+    label: 'Viterbo',
+    value: 'VT'
+  }
+]
+
+const statesUs: State[] = [
+  {
+    label: 'Alabama',
+    value: 'AL'
+  },
+  {
+    label: 'Alaska',
+    value: 'AK'
+  },
+  {
+    label: 'Arizona',
+    value: 'AZ'
+  },
+  {
+    label: 'Arkansas',
+    value: 'AR'
+  },
+  {
+    label: 'California',
+    value: 'CA'
+  },
+  {
+    label: 'Colorado',
+    value: 'CO'
+  },
+  {
+    label: 'Connecticut',
+    value: 'CT'
+  },
+  {
+    label: 'Delaware',
+    value: 'DE'
+  },
+  {
+    label: 'District of Columbia',
+    value: 'DC'
+  },
+  {
+    label: 'Florida',
+    value: 'FL'
+  },
+  {
+    label: 'Georgia',
+    value: 'GA'
+  },
+  {
+    label: 'Hawaii',
+    value: 'HI'
+  },
+  {
+    label: 'Idaho',
+    value: 'ID'
+  },
+  {
+    label: 'Illinois',
+    value: 'IL'
+  },
+  {
+    label: 'Indiana',
+    value: 'IN'
+  },
+  {
+    label: 'Iowa',
+    value: 'IA'
+  },
+  {
+    label: 'Kansas',
+    value: 'KS'
+  },
+  {
+    label: 'Kentucky',
+    value: 'KY'
+  },
+  {
+    label: 'Louisiana',
+    value: 'LA'
+  },
+  {
+    label: 'Maine',
+    value: 'ME'
+  },
+  {
+    label: 'Maryland',
+    value: 'MD'
+  },
+  {
+    label: 'Massachusetts',
+    value: 'MA'
+  },
+  {
+    label: 'Michigan',
+    value: 'MI'
+  },
+  {
+    label: 'Minnesota',
+    value: 'MN'
+  },
+  {
+    label: 'Mississippi',
+    value: 'MS'
+  },
+  {
+    label: 'Missouri',
+    value: 'MO'
+  },
+  {
+    label: 'Montana',
+    value: 'MT'
+  },
+  {
+    label: 'Nebraska',
+    value: 'NE'
+  },
+  {
+    label: 'Nevada',
+    value: 'NV'
+  },
+  {
+    label: 'New Hampshire',
+    value: 'NH'
+  },
+  {
+    label: 'New Jersey',
+    value: 'NJ'
+  },
+  {
+    label: 'New Mexico',
+    value: 'NM'
+  },
+  {
+    label: 'New York',
+    value: 'NY'
+  },
+  {
+    label: 'North Carolina',
+    value: 'NC'
+  },
+  {
+    label: 'North Dakota',
+    value: 'ND'
+  },
+  {
+    label: 'Ohio',
+    value: 'OH'
+  },
+  {
+    label: 'Oklahoma',
+    value: 'OK'
+  },
+  {
+    label: 'Oregon',
+    value: 'OR'
+  },
+  {
+    label: 'Pennsylvania',
+    value: 'PA'
+  },
+  {
+    label: 'Rhode Island',
+    value: 'RI'
+  },
+  {
+    label: 'South Carolina',
+    value: 'SC'
+  },
+  {
+    label: 'South Dakota',
+    value: 'SD'
+  },
+  {
+    label: 'Tennessee',
+    value: 'TN'
+  },
+  {
+    label: 'Texas',
+    value: 'TX'
+  },
+  {
+    label: 'Utah',
+    value: 'UT'
+  },
+  {
+    label: 'Vermont',
+    value: 'VT'
+  },
+  {
+    label: 'Virginia',
+    value: 'VA'
+  },
+  {
+    label: 'Washington',
+    value: 'WA'
+  },
+  {
+    label: 'West Virginia',
+    value: 'WV'
+  },
+  {
+    label: 'Wisconsin',
+    value: 'WI'
+  },
+  {
+    label: 'Wyoming',
+    value: 'WY'
+  }
+]
+
+type CountryCode = (typeof defaultCountries)[number]['value']
+
+export interface Country {
+  value: CountryCode
+  label: string
+}
+
+interface State {
   label: string
   value: string
-}>
-
-export function getCountries(): ReturnStates {
-  return Countries.getCountries({
-    sort: {
-      mode: 'alphabetical',
-      key: 'name'
-    }
-  }).map(({ name, iso2 }) => ({
-    label: name,
-    value: iso2
-  }))
 }
 
-export function getStateOfCountry(country_code: string): ReturnStates {
-  const filters: { country_code: string; is_region?: boolean } = {
-    country_code
-  }
-  if (country_code === 'IT') filters.is_region = false
-  return States.getStates({
-    filters,
-    sort: { mode: 'alphabetical', key: 'name' }
-  }).map(({ name, state_code }) => ({
-    label: name.replace('Province of', ''),
-    value: state_code
-  }))
-}
+export type States = Partial<Record<CountryCode, State[]>>
 
-export function isValidState(
-  state_code: string,
-  country_code: string
-): boolean {
-  return States.getStates({ filters: { state_code, country_code } }).length > 0
+const defaultStates: States = {
+  US: statesUs,
+  IT: statesIt
 }

--- a/packages/react-components/src/utils/isEmptyStates.ts
+++ b/packages/react-components/src/utils/isEmptyStates.ts
@@ -1,5 +1,0 @@
-const countryLock = ['IT', 'US']
-
-export default function isEmptyStates(countryCode: string): boolean {
-  return !countryLock.includes(countryCode)
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,12 +137,6 @@ importers:
 
   packages/react-components:
     dependencies:
-      '@ac-dev/countries-service':
-        specifier: ^1.2.0
-        version: 1.2.0
-      '@ac-dev/states-service':
-        specifier: ^1.1.1
-        version: 1.1.1
       '@adyen/adyen-web':
         specifier: ^5.51.0
         version: 5.51.0
@@ -268,16 +262,6 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /@ac-dev/countries-service@1.2.0:
-    resolution: {integrity: sha512-9+LUUTALFa17EKL7l93ExcjYgHdkcHWlOyvAqMdrVWie6/105eGryQqaba0yIwM4rBYfvs/b/KJHkbcAdSFD2Q==}
-    engines: {node: '>=10'}
-    dev: false
-
-  /@ac-dev/states-service@1.1.1:
-    resolution: {integrity: sha512-a4oOWncXicfEMT4E9RSzZ4uzSSa8GYcCGNReoD15m5Upz7brL+8UKBg6/DjTfPTQ5Rwh7PDVcyigBm8FsnVHYA==}
-    engines: {node: '>=10'}
-    dev: false
 
   /@adyen/adyen-web@5.51.0:
     resolution: {integrity: sha512-jH3Us9k57AhdOrwBL444EQdQ+xTgg4BTD/9/RSOmldw9EM1LzX1+6AKkX/7QioJoYO6L7gI5DUu5iq915ju0IA==}


### PR DESCRIPTION
## What I did

- Removed `@ac-dev/countries-service` and `@ac-dev/states-service` packages, to use an internal and lighter list of countries with states for `US` and `IT`
- Add the ability to pass a custom list of countries for the `AddressCountrySelector` component
- Add the ability to extend the list of States and provide more options for the `AddressStateSelector` component

Examples
```jsx
// shows only FR, IT, US with localized labels as selectable countries
<AddressCountrySelector
  name='billing_address_country_code'
  countries={[
    { value: 'ES', label: 'Espana' },
    { value: 'IT', label: 'Italia' },
    { value: 'US', label: 'Unites States of America' }
  ]}
/>

// shows states as select with predefined options for France
<AddressStateSelector
  name='billing_address_state_code'
  states={{
    FR: [
      { values: 'PA', label: 'Paris' },
      { values: 'LY', label: 'Lyon' },
      { values: 'NI', label: 'Nice' },
      { values: 'MA', label: 'Marseille' },
      { values: 'BO', label: 'Bordeaux' }
    ]
  }}
/>
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
