### PR TITLE
Fix: remove `hasExternalPrice` prop on `<LineItemQuantity>` component

### DIFF
--- a/packages/react-components/src/components/line_items/LineItemQuantity.tsx
+++ b/packages/react-components/src/components/line_items/LineItemQuantity.tsx
@@ -16,16 +16,11 @@ type Props = {
   max?: number
   disabled?: boolean
   readonly?: boolean
-  /**
-   * force the update of the line item price using `_external_price: true` attribute
-   * @link https://docs.commercelayer.io/core/external-resources/external-prices
-   */
-  hasExternalPrice?: boolean
 } & (Omit<JSX.IntrinsicElements['select'], 'children'> &
   Omit<JSX.IntrinsicElements['span'], 'children'>)
 
 export function LineItemQuantity(props: Props): JSX.Element {
-  const { max = 50, readonly = false, hasExternalPrice, ...p } = props
+  const { max = 50, readonly = false, ...p } = props
   const { lineItem } = useContext(LineItemChildrenContext)
   const { updateLineItem } = useContext(LineItemContext)
   const options: ReactNode[] = []
@@ -39,7 +34,7 @@ export function LineItemQuantity(props: Props): JSX.Element {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     const quantity = Number(e.target.value)
     if (updateLineItem && lineItem) {
-      void updateLineItem(lineItem.id, quantity, hasExternalPrice)
+      void updateLineItem(lineItem.id, quantity)
     }
   }
   const quantity = lineItem?.quantity

--- a/packages/react-components/src/components/line_items/LineItemsContainer.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsContainer.tsx
@@ -65,11 +65,10 @@ export function LineItemsContainer(props: Props): JSX.Element {
   const lineItemValue: LineItemContextValue = {
     ...state,
     loader,
-    updateLineItem: async (lineItemId, quantity = 1, hasExternalPrice) => {
+    updateLineItem: async (lineItemId, quantity = 1) => {
       await updateLineItem({
         lineItemId,
         quantity,
-        hasExternalPrice,
         dispatch,
         config,
         getOrder,

--- a/packages/react-components/src/reducers/LineItemReducer.ts
+++ b/packages/react-components/src/reducers/LineItemReducer.ts
@@ -11,7 +11,6 @@ import getErrors from '#utils/getErrors'
 export interface UpdateLineItemParams {
   lineItemId: string
   quantity?: number
-  hasExternalPrice?: boolean
   dispatch: Dispatch<LineItemAction>
   config: CommerceLayerConfig
   getOrder: getOrderContext | undefined
@@ -42,11 +41,7 @@ export interface LineItemPayload {
 }
 
 export interface LineItemState extends LineItemPayload {
-  updateLineItem?: (
-    lineItemId: string,
-    quantity?: number,
-    hasExternalPrice?: boolean
-  ) => Promise<void>
+  updateLineItem?: (lineItemId: string, quantity?: number) => Promise<void>
   deleteLineItem?: (lineItemId: string) => Promise<void>
 }
 
@@ -100,22 +95,10 @@ export const getLineItems: GetLineItems = (params) => {
 export async function updateLineItem(
   params: UpdateLineItemParams
 ): Promise<void> {
-  const {
-    config,
-    lineItemId,
-    quantity,
-    hasExternalPrice,
-    getOrder,
-    orderId,
-    dispatch
-  } = params
+  const { config, lineItemId, quantity, getOrder, orderId, dispatch } = params
   const sdk = getSdk(config)
   try {
-    await sdk.line_items.update({
-      id: lineItemId,
-      quantity,
-      _external_price: hasExternalPrice
-    })
+    await sdk.line_items.update({ id: lineItemId, quantity })
     getOrder && (await getOrder(orderId))
     dispatch({
       type: 'setErrors',


### PR DESCRIPTION
## What I did

This reverts the changes done in  https://github.com/commercelayer/commercelayer-react-components/pull/445 and removes the `hasExternalPrice` prop on the `LineItemQuantity` component.

Mainly we don't need anymore to enforce the update of line_item using the `hasExternalPrice` prop, since now it has been fixed at API level.
The `_external_price` attribute is now being saved on the `line_item` resource.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
