### PR TITLE
Docs: Add `Subscription list` example story

### DIFF
--- a/packages/docs/stories/examples/customer/004.subscriptions.mdx
+++ b/packages/docs/stories/examples/customer/004.subscriptions.mdx
@@ -1,0 +1,41 @@
+import { Meta, Canvas, Source } from '@storybook/addon-docs';
+import * as Stories from './004.subscriptions.stories.tsx'
+
+<Meta of={Stories} />
+
+## Customer Subscriptions
+This guide will explain how to create a customer subscriptions listing page using the Commerce Layer components.
+
+The subscription list will be rendered as a sortable table, depending on the data you want to display and use as columuns.
+You might want to use components shown in this example to render a list of user's subscriptions in their account page.
+
+<span title="Requirements" type="warning">
+To access the customer scope, we will need to pass to our main `<CommerceLayer>` component the `accessToken` for a logged-in user.
+
+Also, all our components will need to stay inside the `<CustomerContainer>` that will hold the customer context.
+  <Source dark code={`
+<CommerceLayer accessToken='customer-orders-access-token'>
+  <CustomerContainer>
+    // customer components that will access the customer context here
+  <CustomerContainer />
+</CommerceLayer>
+  `} language='jsx' />
+</span>
+
+### Full example
+The list is mainly composed by two components: `OrderList` and `OrderListRow` and works around the `order subscription` object.
+
+- The `OrderList` component provides a `type` prop to specify which kind of resources are to be listed (`orders` or `subscriptions`). You need to set this prop as `subscriptions` in this case.
+- You can specify the `columns` you need to handle using the relative props in `<OrderList>`. Each columns is linked to an attribute of the `order subscription` object.
+- Each value is then rendered with a `<OrderListRow>` component, which is a `<td>` element attached to a specific `field` of the `order subscription` object.
+
+<span title="Rendering custom cell value" type="info">
+  `<OrderListRow>` works out the box by automatically render the value of the field in a `<td>` tag, 
+  but you can also use `children` prop to customize the output that will be rendered inside the `<td>` tag.
+  Just remember that you don't have to write the `<td>` tag, **but only the inner content**.
+  <br /><br />
+  In the following example you can notice that the `<OrderListRow field='number'>` cell uses a custom children render,
+  while content of other cells is rendered with the default values.
+</span>
+
+<Canvas of={Stories.Default} />

--- a/packages/docs/stories/examples/customer/004.subscriptions.stories.tsx
+++ b/packages/docs/stories/examples/customer/004.subscriptions.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryFn } from '@storybook/react'
+import CommerceLayer from '../../_internals/CommerceLayer'
+import CustomerContainer from '#components/customers/CustomerContainer'
+import OrderList from '#components/orders/OrderList'
+import OrderListEmpty from '#components/orders/OrderListEmpty'
+import OrderListRow from '#components/orders/OrderListRow'
+import OrderListPaginationButtons from '#components/orders/OrderListPaginationButtons'
+import OrderListPaginationInfo from '#components/orders/OrderListPaginationInfo'
+
+const setup: Meta = {
+  title: 'Examples/Customer Account/Subscription list'
+}
+
+export default setup
+
+export const Default: StoryFn = (args) => {
+  const colClassName = 'uppercase text-left p-1 text-gray-400 text-sm'
+  const titleClassName = 'flex flex-row items-center gap-3 py-3'
+
+  const columns: React.ComponentProps<typeof OrderList>['columns'] = [
+    {
+      header: 'Subscription',
+      accessorKey: 'number',
+      className: colClassName,
+      titleClassName
+    },
+    {
+      header: 'Started',
+      accessorKey: 'starts_at',
+      className: colClassName,
+      titleClassName
+    },
+    {
+      header: 'Status',
+      accessorKey: 'status',
+      className: colClassName,
+      titleClassName
+    },
+    {
+      header: 'Frequency',
+      accessorKey: 'frequency',
+      className: colClassName,
+      titleClassName
+    },
+    {
+      header: 'Next run',
+      accessorKey: 'next_run_at',
+      className: colClassName,
+      titleClassName
+    }
+  ]
+
+  return (
+    <CommerceLayer accessToken='customer-orders-access-token'>
+      <CustomerContainer>
+        <OrderList
+          type='subscriptions'
+          className='table-fixed w-full border-collapse'
+          columns={columns}
+          theadClassName='thead-class bg-gray-100'
+          rowTrClassName='row-tr-class border-b'
+          showPagination
+          pageSize={15}
+          paginationContainerClassName='flex justify-between items-center'
+        >
+          <OrderListEmpty emptyText='No subscriptions available' />
+
+          <OrderListRow field='number'>
+            {({ cell, order, ...p }) => {
+              return (
+                <>
+                  {cell?.map((cell) => (
+                    <div {...p} key={cell.id} className='py-5'>
+                      <p className='font-bold'>
+                        Subscription # {cell.renderValue<string>()}
+                      </p>
+                      {order.type === 'order_subscriptions' ? null : (
+                        <p className='text-xs text-gray-500'>
+                          contains {order.skus_count} items
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </>
+              )
+            }}
+          </OrderListRow>
+          <OrderListRow field='starts_at' className='align-top py-5 border-b' />
+          <OrderListRow field='status' className='align-top py-5 border-b' />
+          <OrderListRow field='frequency' className='align-top py-5 border-b' />
+          <OrderListRow
+            field='next_run_at'
+            className='align-top py-5 border-b'
+          />
+          <OrderListPaginationInfo className='text-sm text-gray-500' />
+          <OrderListPaginationButtons
+            previousPageButton={{
+              className:
+                'w-[46px] h-[38px] mr-2 border rounded text-sm text-gray-500',
+              show: true,
+              hideWhenDisabled: true
+            }}
+            nextPageButton={{
+              className:
+                'w-[46px] h-[38px] mr-2 border rounded text-sm text-gray-500',
+              show: true,
+              hideWhenDisabled: true
+            }}
+            navigationButtons={{
+              className:
+                'w-[46px] h-[38px] mr-2 border rounded text-sm text-gray-500',
+              activeClassName:
+                'text-primary font-semibold border-primary border-2'
+            }}
+            className='p-2'
+          />
+        </OrderList>
+      </CustomerContainer>
+    </CommerceLayer>
+  )
+}
+
+Default.parameters = {
+  docs: {
+    source: {
+      type: 'code'
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added a documentation story about `Customer account > Subscription list` in `Examples` section of Storybook.
Following what is shown in `Order list` story of same section here we tell how to create a customer order subscription list using `OrderList` component configured with `type="subscriptions"` prop.
