### PR TITLE
fix: Improve the retrieval of orders of an order subscription

### DIFF
--- a/packages/react-components/src/components/customers/CustomerContainer.tsx
+++ b/packages/react-components/src/components/customers/CustomerContainer.tsx
@@ -197,18 +197,18 @@ export function CustomerContainer(props: Props): JSX.Element {
       getCustomerSubscriptions: async ({
         pageNumber,
         pageSize,
-        number
+        id
       }: {
         pageNumber?: number
         pageSize?: number
-        number?: string
+        id?: string
       }) => {
         await getCustomerSubscriptions({
           config,
           dispatch,
           pageNumber,
           pageSize,
-          number
+          id
         })
       }
     }

--- a/packages/react-components/src/components/customers/CustomerContainer.tsx
+++ b/packages/react-components/src/components/customers/CustomerContainer.tsx
@@ -203,7 +203,7 @@ export function CustomerContainer(props: Props): JSX.Element {
         pageSize?: number
         number?: string
       }) => {
-        await getCustomerOrders({
+        await getCustomerSubscriptions({
           config,
           dispatch,
           pageNumber,

--- a/packages/react-components/src/components/orders/OrderList.tsx
+++ b/packages/react-components/src/components/orders/OrderList.tsx
@@ -64,11 +64,11 @@ type SubscriptionFields =
       /**
        * Subscriptions id - Use to fetch subscriptions and shows its orders
        */
-      number?: string
+      id?: string
       type?: 'subscriptions'
     }
   | {
-      number?: never
+      id?: never
       type?: 'orders'
     }
 
@@ -124,7 +124,7 @@ type Props = {
   SubscriptionFields
 
 export function OrderList({
-  number,
+  id,
   type = 'orders',
   children,
   columns,
@@ -160,10 +160,10 @@ export function OrderList({
       void getCustomerSubscriptions({
         pageNumber: pageIndex + 1,
         pageSize: currentPageSize,
-        number
+        id
       })
     }
-  }, [pageIndex, currentPageSize, number != null])
+  }, [pageIndex, currentPageSize, id != null])
   const data = useMemo(() => {
     if (type === 'subscriptions') return subscriptions ?? []
     return orders ?? []

--- a/packages/react-components/src/components/orders/OrderList.tsx
+++ b/packages/react-components/src/components/orders/OrderList.tsx
@@ -279,7 +279,10 @@ export function OrderList({
     componentName: 'OrderList'
   })
   const totalRows =
-    orders?.meta.recordCount ?? subscriptions?.meta.recordCount ?? 0
+    type === 'orders'
+      ? orders?.meta.recordCount ?? 0
+      : subscriptions?.meta.recordCount ?? 0
+
   const Pagination = (): JSX.Element | null =>
     !showPagination ? null : (
       <OrderListPagination.Provider

--- a/packages/react-components/src/reducers/CustomerReducer.ts
+++ b/packages/react-components/src/reducers/CustomerReducer.ts
@@ -267,9 +267,9 @@ interface GetCustomerOrdersProps {
    */
   pageNumber?: number
   /**
-   * Retrieve a specific subscription or order by number
+   * Retrieve a specific subscription or order by id
    */
-  number?: string
+  id?: string
 }
 
 export async function getCustomerOrders({
@@ -296,7 +296,7 @@ export async function getCustomerOrders({
 }
 
 export async function getCustomerSubscriptions({
-  number,
+  id,
   config,
   dispatch,
   pageSize = 10,
@@ -306,9 +306,9 @@ export async function getCustomerSubscriptions({
     const { owner } = jwt(config.accessToken)
     if (owner?.id) {
       const sdk = getSdk(config)
-      if (number != null) {
+      if (id != null) {
         const subscriptions = await sdk.customers.orders(owner.id, {
-          filters: { order_subscription_number_eq: number },
+          filters: { order_subscription_id_eq: id },
           pageSize,
           pageNumber
         })

--- a/packages/react-components/src/reducers/CustomerReducer.ts
+++ b/packages/react-components/src/reducers/CustomerReducer.ts
@@ -309,6 +309,7 @@ export async function getCustomerSubscriptions({
       if (id != null) {
         const subscriptions = await sdk.customers.orders(owner.id, {
           filters: { order_subscription_id_eq: id },
+          include: ['authorizations'],
           pageSize,
           pageNumber
         })


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Updated the method to get orders subscriptions orders in `CustomerContainer` component
- Enforced the calculation of the `totalRows` count in `OrderList` component
- Updated the `msw` implementation from v1.x to v2.x according to official [documentation](https://mswjs.io/docs/migrations/1.x-to-2.x/#ctxfetch)
- Renamed from `number` to `id` the `OrderList` and related components prop used to optionally retrieve children resources of a single parent resource