### PR TITLE
Enforce `OrderList` data for subscription orders

### DIFF
--- a/packages/react-components/src/components/orders/OrderList.tsx
+++ b/packages/react-components/src/components/orders/OrderList.tsx
@@ -165,8 +165,19 @@ export function OrderList({
     }
   }, [pageIndex, currentPageSize, id != null])
   const data = useMemo(() => {
-    if (type === 'subscriptions') return subscriptions ?? []
-    return orders ?? []
+    if (type === 'orders') {
+      return orders ?? []
+    }
+
+    if (id === null) {
+      return subscriptions ?? []
+    }
+
+    if (subscriptions?.[0]?.type === 'orders') {
+      return subscriptions
+    }
+
+    return []
   }, [orders, subscriptions])
   const cols = useMemo<Array<ColumnDef<OrderListContent<TOrderList>>>>(
     () => columns,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enforced the `OrderList` component data calculation to manage all the usages of component props that are influencing the content of its rows.