### PR TITLE
Fx typo in states documentation

### DIFF
--- a/packages/docs/stories/examples/customer/002.address-form.mdx
+++ b/packages/docs/stories/examples/customer/002.address-form.mdx
@@ -78,11 +78,11 @@ You can customize both the lists of countries and states by passing the `countri
   name='billing_address_state_code'
   states={{
     FR: [
-      { values: 'PA', label: 'Paris' },
-      { values: 'LY', label: 'Lyon' },
-      { values: 'NI', label: 'Nice' },
-      { values: 'MA', label: 'Marseille' },
-      { values: 'BO', label: 'Bordeaux' }
+      { value: 'PA', label: 'Paris' },
+      { value: 'LY', label: 'Lyon' },
+      { value: 'NI', label: 'Nice' },
+      { value: 'MA', label: 'Marseille' },
+      { value: 'BO', label: 'Bordeaux' }
     ]
   }}
 />


### PR DESCRIPTION
I've fixed a small typo in documentation replacing `values` with `value`