### PR TITLE
Add `codeType` to gift card or coupon code components

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.12.0-beta.0",
+  "version": "4.12.0-beta.1",
   "command": {
     "version": {
       "preid": "beta"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.11.3",
+  "version": "4.12.0-beta.0",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/docs/stories/examples/cart/001.cart.mdx
+++ b/packages/docs/stories/examples/cart/001.cart.mdx
@@ -18,4 +18,8 @@ Again, all sections are wrapped inside the same `<OrderContainer>` component, wh
 Use `TEST-COUPON` to add a 10% discount code and see how the totals change.
 </span>
 
+<span title="Gift card" type="info">
+Use `0513f118-dcc1-4ba5-b5c1-e83b6055ca6a` to add a 100€ discount and see how the totals change.
+</span>
+
 <Canvas of={Stories.Default} />

--- a/packages/docs/stories/examples/cart/001.cart.stories.tsx
+++ b/packages/docs/stories/examples/cart/001.cart.stories.tsx
@@ -64,8 +64,22 @@ export const Default: StoryFn = (args) => {
           </section>
 
           <section className='p-6 border rounded-lg mb-4'>
-            <legend className='text-lg font-bold'>Gift cart or coupon</legend>
-            <GiftCardOrCouponForm>
+            <legend className='text-lg font-bold'>Coupon</legend>
+            <GiftCardOrCouponForm codeType='coupon_code'>
+              <GiftCardOrCouponInput className='border p-2' />
+              <GiftCardOrCouponSubmit className='px-4 py-2 bg-black border text-white' />
+            </GiftCardOrCouponForm>
+            <div className='flex'>
+              <GiftCardOrCouponCode type='coupon' />
+              <GiftCardOrCouponRemoveButton
+                type='coupon'
+                className='px-4 py-2 bg-black border text-white'
+              />
+            </div>
+          </section>
+          <section className='p-6 border rounded-lg mb-4'>
+            <legend className='text-lg font-bold'>Gift Card</legend>
+            <GiftCardOrCouponForm codeType='gift_card_code'>
               <GiftCardOrCouponInput className='border p-2' />
               <GiftCardOrCouponSubmit className='px-4 py-2 bg-black border text-white' />
             </GiftCardOrCouponForm>

--- a/packages/docs/stories/examples/cart/001.cart.stories.tsx
+++ b/packages/docs/stories/examples/cart/001.cart.stories.tsx
@@ -84,8 +84,11 @@ export const Default: StoryFn = (args) => {
               <GiftCardOrCouponSubmit className='px-4 py-2 bg-black border text-white' />
             </GiftCardOrCouponForm>
             <div className='flex'>
-              <GiftCardOrCouponCode />
-              <GiftCardOrCouponRemoveButton className='px-4 py-2 bg-black border text-white' />
+              <GiftCardOrCouponCode type='gift_card' />
+              <GiftCardOrCouponRemoveButton
+                type='gift_card'
+                className='px-4 py-2 bg-black border text-white'
+              />
             </div>
           </section>
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.12.0-beta.0",
+  "version": "4.12.0-beta.1",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.11.3",
+  "version": "4.12.0-beta.0",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/src/components/addresses/BillingAddressForm.tsx
+++ b/packages/react-components/src/components/addresses/BillingAddressForm.tsx
@@ -87,7 +87,6 @@ export function BillingAddressForm(props: Props): JSX.Element {
           const fieldName = field.name
           const value = field.value
           const inError = errors[fieldName] != null
-          console.log('inError', inError)
           if (
             customFieldMessageError != null &&
             fieldName != null &&

--- a/packages/react-components/src/components/addresses/BillingAddressForm.tsx
+++ b/packages/react-components/src/components/addresses/BillingAddressForm.tsx
@@ -21,6 +21,7 @@ type Props = {
    * Define children input and select classnames assigned in case of validation error.
    */
   errorClassName?: string
+  fieldEvent?: 'blur' | 'change'
   /**
    * Callback to customize the error message for a specific field. Called for each error in the form.
    */
@@ -48,6 +49,7 @@ export function BillingAddressForm(props: Props): JSX.Element {
     autoComplete = 'on',
     reset = false,
     customFieldMessageError,
+    fieldEvent = 'change',
     ...p
   } = props
   const {
@@ -57,7 +59,7 @@ export function BillingAddressForm(props: Props): JSX.Element {
     reset: resetForm,
     setValue: setValueForm,
     setError: setErrorForm
-  } = useRapidForm()
+  } = useRapidForm({ fieldEvent })
   const { setAddressErrors, setAddress, isBusiness } =
     useContext(AddressesContext)
   const {

--- a/packages/react-components/src/components/addresses/ShippingAddressForm.tsx
+++ b/packages/react-components/src/components/addresses/ShippingAddressForm.tsx
@@ -13,6 +13,7 @@ interface Props extends Omit<JSX.IntrinsicElements['form'], 'onSubmit'> {
   children: ReactNode
   reset?: boolean
   errorClassName?: string
+  fieldEvent?: 'blur' | 'change'
   /**
    * Callback to customize the error message for a specific field. Called for each error in the form.
    */
@@ -41,6 +42,7 @@ export function ShippingAddressForm(props: Props): JSX.Element {
     children,
     errorClassName,
     autoComplete = 'on',
+    fieldEvent = 'change',
     reset = false,
     customFieldMessageError,
     ...p
@@ -52,7 +54,7 @@ export function ShippingAddressForm(props: Props): JSX.Element {
     reset: resetForm,
     setValue: setValueForm,
     setError: setErrorForm
-  } = useRapidForm()
+  } = useRapidForm({ fieldEvent })
   const {
     setAddressErrors,
     setAddress,

--- a/packages/react-components/src/components/gift_cards/GiftCardOrCouponCode.tsx
+++ b/packages/react-components/src/components/gift_cards/GiftCardOrCouponCode.tsx
@@ -3,8 +3,6 @@ import { type ChildrenFunction } from '#typings'
 import Parent from '#components/utils/Parent'
 import OrderContext from '#context/OrderContext'
 import type { CodeType } from '#reducers/OrderReducer'
-import has from 'lodash/has'
-import isEmpty from 'lodash/isEmpty'
 
 interface ChildrenProps extends Omit<Props, 'children' | 'type'> {
   code?: string | null
@@ -25,13 +23,8 @@ export function GiftCardOrCouponCode({
   ...props
 }: Props): JSX.Element | null {
   const { order } = useContext(OrderContext)
-  let codeType = type && (`${type}_code` as const)
-  if (
-    !type &&
-    order &&
-    has(order, 'coupon_code') &&
-    !isEmpty(order.coupon_code)
-  )
+  let codeType = type ? (`${type}_code` as const) : undefined
+  if (!type && order && 'coupon_code' in order && order.coupon_code !== '')
     codeType = 'coupon_code'
   else if (!type) codeType = 'gift_card_code'
   const code = order && codeType ? order[codeType] : ''

--- a/packages/react-components/src/components/gift_cards/GiftCardOrCouponCode.tsx
+++ b/packages/react-components/src/components/gift_cards/GiftCardOrCouponCode.tsx
@@ -6,7 +6,7 @@ import type { CodeType } from '#reducers/OrderReducer'
 import has from 'lodash/has'
 import isEmpty from 'lodash/isEmpty'
 
-interface ChildrenProps extends Omit<Props, 'children'> {
+interface ChildrenProps extends Omit<Props, 'children' | 'type'> {
   code?: string | null
   hide?: boolean
   discountAmountCents?: number | null
@@ -34,7 +34,6 @@ export function GiftCardOrCouponCode({
   )
     codeType = 'coupon_code'
   else if (!type) codeType = 'gift_card_code'
-  // @ts-expect-error deprecate `gift_card_or_coupon_code`
   const code = order && codeType ? order[codeType] : ''
   const hide = !(order && code)
   const parentProps: ChildrenProps = {

--- a/packages/react-components/src/components/gift_cards/GiftCardOrCouponForm.tsx
+++ b/packages/react-components/src/components/gift_cards/GiftCardOrCouponForm.tsx
@@ -1,5 +1,5 @@
 import { useRapidForm } from 'rapid-form'
-import { useContext, useEffect, useRef } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import CouponAndGiftCardFormContext from '#context/CouponAndGiftCardFormContext'
 import OrderContext from '#context/OrderContext'
 import type { OrderCodeType } from '#reducers/OrderReducer'
@@ -28,34 +28,47 @@ export function GiftCardOrCouponForm(props: Props): JSX.Element | null {
   const { setGiftCardOrCouponCode, order, errors, setOrderErrors } =
     useContext(OrderContext)
   const ref = useRef<HTMLFormElement>(null)
+  const [type, setType] = useState(codeType)
   useEffect(() => {
-    if (values[codeType]?.value === '' && errors != null && errors.length > 0) {
-      const err = errors.filter((e) => e.field === codeType)
+    if (values[type]?.value === '' && errors != null && errors.length > 0) {
+      const err = errors.filter((e) => e.field === type)
       setOrderErrors(err)
       if (onSubmit) {
-        onSubmit({ value: values[codeType]?.value, success: false })
+        onSubmit({ value: values[type]?.value, success: false })
       }
     }
-    if (values[codeType]?.value === '') {
+    if (values[type]?.value === '') {
       setOrderErrors([])
       if (onSubmit) {
-        onSubmit({ value: values[codeType]?.value, success: false })
+        onSubmit({ value: values[type]?.value, success: false })
       }
     }
   }, [values])
+
+  useEffect(() => {
+    if (order?.gift_card_code && !order?.coupon_code) {
+      setType('coupon_code')
+    }
+    if (!order?.gift_card_code && order?.coupon_code) {
+      setType('gift_card_code')
+    }
+    if (!order?.gift_card_code && !order?.coupon_code) {
+      setType('gift_card_or_coupon_code')
+    }
+  }, [order])
 
   const handleSubmit = async (
     e: React.FormEvent<HTMLFormElement>
   ): Promise<void> => {
     e.preventDefault()
-    const code = values[codeType] != null ? values[codeType].value : undefined
-    if (code != null && setGiftCardOrCouponCode != null && codeType != null) {
+    const code = values[type] != null ? values[type].value : undefined
+    if (code != null && setGiftCardOrCouponCode != null && type != null) {
       const { success, order } = await setGiftCardOrCouponCode({
         code,
         // TODO: Remove the `as` assertion
-        codeType: codeType as OrderCodeType
+        codeType: type as OrderCodeType
       })
-      const value = values[codeType]?.value
+      const value = values[type]?.value
       if (onSubmit) {
         onSubmit({
           success,
@@ -66,9 +79,10 @@ export function GiftCardOrCouponForm(props: Props): JSX.Element | null {
       if (success) reset(e)
     }
   }
-  return order?.[codeType as OrderCodeType] || order == null ? null : (
+  return (order?.gift_card_code && order?.coupon_code) ||
+    order == null ? null : (
     <CouponAndGiftCardFormContext.Provider
-      value={{ validation, codeType: codeType as OrderCodeType }}
+      value={{ validation, codeType: type as OrderCodeType }}
     >
       <form
         ref={ref}

--- a/packages/react-components/src/components/gift_cards/GiftCardOrCouponInput.tsx
+++ b/packages/react-components/src/components/gift_cards/GiftCardOrCouponInput.tsx
@@ -4,20 +4,23 @@ import CouponAndGiftCardFormContext from '#context/CouponAndGiftCardFormContext'
 import { type BaseInputComponentProps } from '#typings'
 import { type OrderCodeType } from '#reducers/OrderReducer'
 
+type FieldName = 'gift_card_code' | 'coupon_code'
+
 type Props = {
-  name?: 'gift_card_or_coupon_code'
+  name?: FieldName
   type?: 'text'
   placeholderTranslation?: (codeType: OrderCodeType) => string
 } & Omit<BaseInputComponentProps, 'name' | 'type'> &
   Omit<JSX.IntrinsicElements['input'], 'children'> &
   Omit<JSX.IntrinsicElements['textarea'], 'children'>
 
-export function GiftCardOrCouponInput(props: Props): JSX.Element {
+export function GiftCardOrCouponInput(props: Props): JSX.Element | null {
   const {
     placeholder = '',
     required,
     value,
     placeholderTranslation,
+    name,
     ...p
   } = props
   const { validation, codeType } = useContext(CouponAndGiftCardFormContext)
@@ -25,10 +28,10 @@ export function GiftCardOrCouponInput(props: Props): JSX.Element {
   if (placeholderTranslation && codeType) {
     placeholderLabel = placeholderTranslation(codeType)
   }
-  return (
+  return codeType == null ? null : (
     <BaseInput
       type='text'
-      name='gift_card_or_coupon_code'
+      name={codeType ?? 'gift_card_or_coupon_code'}
       ref={validation as any}
       required={required !== undefined ? required : true}
       placeholder={placeholderLabel}

--- a/packages/react-components/src/components/gift_cards/GiftCardOrCouponRemoveButton.tsx
+++ b/packages/react-components/src/components/gift_cards/GiftCardOrCouponRemoveButton.tsx
@@ -22,10 +22,9 @@ export function GiftCardOrCouponRemoveButton(props: Props): JSX.Element | null {
   const { children, label = 'Remove', onClick, type, ...p } = props
   const { order, removeGiftCardOrCouponCode } = useContext(OrderContext)
   let codeType = type ? (`${type}_code` as const) : undefined
-  if (!type && order && 'coupon_code' in order && order.coupon_code != null)
+  if (!type && order && 'coupon_code' in order && order.coupon_code !== '')
     codeType = 'coupon_code'
   else if (!type) codeType = 'gift_card_code'
-  // @ts-expect-error deprecate `gift_card_or_coupon_code`
   const code = order && codeType ? order[codeType] : ''
   const hide = !(order && code)
   const handleClick = async (): Promise<void> => {

--- a/packages/react-components/src/reducers/OrderReducer.ts
+++ b/packages/react-components/src/reducers/OrderReducer.ts
@@ -629,7 +629,7 @@ export async function setGiftCardOrCouponCode({
   }
 }
 
-export type CodeType = 'coupon' | 'gift_card' | 'gift_card_or_coupon'
+export type CodeType = 'coupon' | 'gift_card'
 export type OrderCodeType = `${CodeType}_code`
 
 interface TRemoveGiftCardOrCouponCodeParams {


### PR DESCRIPTION
- **fix: Set code type on Gift card or coupon components**
- **feat: Add new prop `fieldEvent` to Billing and Shipping address components**
