### PR TITLE
Move side padding from mini cart body to iframe

### DIFF
--- a/packages/react-components/src/components/orders/HostedCart.tsx
+++ b/packages/react-components/src/components/orders/HostedCart.tsx
@@ -42,7 +42,9 @@ const defaultIframeStyle = {
   width: '1px',
   minWidth: '100%',
   minHeight: '100%',
-  border: 'none'
+  border: 'none',
+  paddingLeft: '20px',
+  paddingRight: '20px',
 } satisfies CSSProperties
 
 const defaultContainerStyle = {
@@ -285,8 +287,7 @@ export function HostedCart({
     iframeResizer(
       {
         checkOrigin: false,
-        bodyPadding: '20px',
-        // @ts-expect-error No types available
+         // @ts-expect-error No types available
         onMessage
       },
       ref.current


### PR DESCRIPTION
## What I did

On mini-cart, during the first loading, the iframe event could be not fully synched with the loading of the cart URL, so side padding sometimes is not applied.
A safer solution is to have the same padding left and right applied directly to the iframe tag, without relying on iframe events.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
