### PR TITLE
Avoid show card for wiretransfer and paypal payment methods.

### DIFF
--- a/packages/react-components/src/components/payment_gateways/PaypalGateway.tsx
+++ b/packages/react-components/src/components/payment_gateways/PaypalGateway.tsx
@@ -21,7 +21,7 @@ export function PaypalGateway(props: Props): JSX.Element | null {
   const paymentResource: PaymentResource = 'paypal_payments'
 
   if (!readonly && payment?.id !== currentPaymentMethodId) return null
-  if (readonly || showCard) {
+  if (readonly) {
     const card = getCardDetails({
       customerPayment: {
         // @ts-expect-error missing type

--- a/packages/react-components/src/components/payment_gateways/WireTransferGateway.tsx
+++ b/packages/react-components/src/components/payment_gateways/WireTransferGateway.tsx
@@ -23,7 +23,7 @@ export function WireTransferGateway(props: Props): JSX.Element | null {
   const paymentResource: PaymentResource = 'wire_transfers'
 
   if (!readonly && payment?.id !== currentPaymentMethodId) return null
-  if (readonly || showCard) {
+  if (readonly) {
     const card = getCardDetails({
       customerPayment: {
         // @ts-expect-error no type


### PR DESCRIPTION
- **Avoid double click on selecting a shipping method.**
- **Avoid show card for wiretransfer and paypal payment methods.**
