### PR TITLE
Fix  sort order list

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -227,7 +227,7 @@
     "@types/react-test-renderer": "^18.3.1",
     "@types/react-window": "^1.8.8",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^3.0.4",
+    "@vitest/coverage-v8": "^3.0.5",
     "jsdom": "^26.0.0",
     "minimize-js": "^1.4.0",
     "msw": "^2.7.0",
@@ -239,7 +239,7 @@
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.4"
+    "vitest": "^3.0.5"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -227,7 +227,7 @@
     "@types/react-test-renderer": "^18.3.1",
     "@types/react-window": "^1.8.8",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^3.0.5",
+    "@vitest/coverage-v8": "^3.0.7",
     "jsdom": "^26.0.0",
     "minimize-js": "^1.4.0",
     "msw": "^2.7.0",
@@ -239,7 +239,7 @@
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.5"
+    "vitest": "^3.0.7"
   },
   "peerDependencies": {
     "react": ">=18.0.0"


### PR DESCRIPTION
This pull request includes updates to dependencies and enhancements to the `CustomerReducer` in the `packages/react-components` package. The most important changes include upgrading dependencies in `package.json` and adding sorting capabilities to the `getCustomerOrders` and `getCustomerSubscriptions` functions.

Dependency updates:

* [`packages/react-components/package.json`](diffhunk://#diff-6adad24655c6ad668b62d38efb24e18aa0dbb3c97e4243fc83d43338bb96e6ecL230-R230): Upgraded `@vitest/coverage-v8` from `^3.0.4` to `^3.0.7` and `vitest` from `^3.0.4` to `^3.0.7`. [[1]](diffhunk://#diff-6adad24655c6ad668b62d38efb24e18aa0dbb3c97e4243fc83d43338bb96e6ecL230-R230) [[2]](diffhunk://#diff-6adad24655c6ad668b62d38efb24e18aa0dbb3c97e4243fc83d43338bb96e6ecL242-R242)

Enhancements to `CustomerReducer`:

* [`packages/react-components/src/reducers/CustomerReducer.ts`](diffhunk://#diff-c987e523eafc0f89a9de7f0d58033d1b09d3a02fd0403b24c7f9538576977869L14-R15): Added `QuerySort` to the import statements.
* [`packages/react-components/src/reducers/CustomerReducer.ts`](diffhunk://#diff-c987e523eafc0f89a9de7f0d58033d1b09d3a02fd0403b24c7f9538576977869R287-R299): Added a `sort` parameter to the `GetCustomerOrdersProps` interface and the `getCustomerOrders` function, with a default value of `{ created_at: 'desc' }`. [[1]](diffhunk://#diff-c987e523eafc0f89a9de7f0d58033d1b09d3a02fd0403b24c7f9538576977869R287-R299) [[2]](diffhunk://#diff-c987e523eafc0f89a9de7f0d58033d1b09d3a02fd0403b24c7f9538576977869L301-R309)
* [`packages/react-components/src/reducers/CustomerReducer.ts`](diffhunk://#diff-c987e523eafc0f89a9de7f0d58033d1b09d3a02fd0403b24c7f9538576977869L316-R352): Added a `sort` parameter to the `getCustomerSubscriptions` function, with a default value of `{ created_at: 'desc' }` and appropriate handling for sorting orders and subscriptions.

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
