### PR TITLE
Enable server side sorting for order subscriptions

### DIFF
--- a/packages/react-components/src/components/customers/CustomerContainer.tsx
+++ b/packages/react-components/src/components/customers/CustomerContainer.tsx
@@ -207,10 +207,12 @@ export function CustomerContainer(props: Props): JSX.Element {
       getCustomerSubscriptions: async ({
         pageNumber,
         pageSize,
+        sortBy,
         id
       }: {
         pageNumber?: number
         pageSize?: QueryPageSize
+        sortBy?: QuerySort<Order>
         id?: string
       }) => {
         await getCustomerSubscriptions({
@@ -218,6 +220,7 @@ export function CustomerContainer(props: Props): JSX.Element {
           dispatch,
           pageNumber,
           pageSize,
+          sortBy,
           id
         })
       },

--- a/packages/react-components/src/components/orders/OrderList.tsx
+++ b/packages/react-components/src/components/orders/OrderList.tsx
@@ -168,6 +168,7 @@ export function OrderList({
       getCustomerSubscriptions({
         pageNumber: pageIndex + 1,
         pageSize: currentPageSize as QueryPageSize,
+        sortBy: sdkSorting as QuerySort<Order>,
         id
       })
     }

--- a/packages/react-components/src/reducers/CustomerReducer.ts
+++ b/packages/react-components/src/reducers/CustomerReducer.ts
@@ -263,9 +263,7 @@ export function getCustomerPaymentSources(
   }
 }
 
-type GetCustomerOrdersResource = Order | OrderSubscription
-
-interface GetCustomerOrdersProps<T extends GetCustomerOrdersResource> {
+interface GetCustomerOrdersProps {
   /**
    * The Commerce Layer config
    */
@@ -285,7 +283,7 @@ interface GetCustomerOrdersProps<T extends GetCustomerOrdersResource> {
   /**
    * The sort order
    */
-  sortBy?: QuerySort<T>
+  sortBy?: QuerySort<Order>
   /**
    * Retrieve a specific subscription or order by id
    */
@@ -298,7 +296,7 @@ export async function getCustomerOrders({
   pageSize = 10,
   pageNumber = 1,
   sortBy
-}: GetCustomerOrdersProps<Order>): Promise<void> {
+}: GetCustomerOrdersProps): Promise<void> {
   if (config.accessToken) {
     const { owner } = jwt(config.accessToken)
     if (owner?.id) {
@@ -322,8 +320,9 @@ export async function getCustomerSubscriptions({
   config,
   dispatch,
   pageSize = 10,
-  pageNumber = 1
-}: GetCustomerOrdersProps<OrderSubscription>): Promise<void> {
+  pageNumber = 1,
+  sortBy
+}: GetCustomerOrdersProps): Promise<void> {
   if (config.accessToken) {
     const { owner } = jwt(config.accessToken)
     if (owner?.id) {
@@ -331,6 +330,7 @@ export async function getCustomerSubscriptions({
       if (id != null) {
         const subscriptions = await sdk.customers.orders(owner.id, {
           filters: { order_subscription_id_eq: id },
+          sort: sortBy ?? { number: 'desc'},
           include: ['authorizations'],
           pageSize,
           pageNumber
@@ -343,6 +343,7 @@ export async function getCustomerSubscriptions({
         const subscriptions = await sdk.customers.order_subscriptions(
           owner.id,
           {
+            sort: (sortBy ?? { starts_at: 'desc'}) as QuerySort<OrderSubscription>,
             pageSize,
             pageNumber
           }
@@ -430,7 +431,7 @@ export async function createCustomerAddress({
   }
 }
 
-interface GetCustomerPaymentsParams extends GetCustomerOrdersProps<Order> {}
+interface GetCustomerPaymentsParams extends GetCustomerOrdersProps {}
 
 export async function getCustomerPayments({
   config,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Following the previous PR related to enabling server side ordering to the `OrderList` component we now gave support for the server side ordering when the component is used for showing `order subscriptions` and orders related to an order subscription.