### PR TITLE
Fix for Custom Field Error Causing Address not Saving to Address Book

### DIFF
--- a/packages/react-components/src/components/addresses/BillingAddressForm.tsx
+++ b/packages/react-components/src/components/addresses/BillingAddressForm.tsx
@@ -91,7 +91,6 @@ export function BillingAddressForm(props: Props): JSX.Element {
             fieldName != null &&
             value != null
           ) {
-            values[fieldName.replace("shipping_address_", "")] = value
             const customMessage = customFieldMessageError({
               field: fieldName,
               value,


### PR DESCRIPTION
## What I did

<!-- Briefly describe what your PR does -->
Removed possibly leftover code which manipulates the save address checkbox data passed into the component when a custom field error callback is passed into billing address form. This change in data prevents `saveAddressToCustomerAddressBook` from being called as the data no longer has attribute of type checkbox

## How to test

<!-- Please include the steps to test your changes here -->
1. Pass in a callback function to BillingAddressForm component
2. Tick the checkbox for saving address of customer
3. Value of local storage variable to save customer address should be updated to True on submission

