### PR TITLE
Refresh order when billing or shipping address is updated

### DIFF
--- a/packages/react-components/src/reducers/AddressReducer.ts
+++ b/packages/react-components/src/reducers/AddressReducer.ts
@@ -27,11 +27,11 @@ export type CustomFieldMessageError = (props: {
   | string
   | null
   | Array<{
-      field: Extract<AddressValuesKeys, AddressInputName> | string
-      value: string
-      isValid: boolean
-      message?: string
-    }>
+    field: Extract<AddressValuesKeys, AddressInputName> | string
+    value: string
+    isValid: boolean
+    message?: string
+  }>
 
 export type AddressActionType =
   | "setErrors"
@@ -268,6 +268,7 @@ export async function saveAddresses({
               id: order.billing_address.id,
               ...billingAddressWithMeta,
             })
+            orderAttributes._refresh = true
           } else {
             address = await sdk.addresses.create(billingAddressWithMeta)
             orderAttributes.billing_address = sdk.addresses.relationship(
@@ -303,6 +304,7 @@ export async function saveAddresses({
                 id: order.shipping_address.id,
                 ...shippingAddressWithMeta,
               })
+              orderAttributes._refresh = true
             } else {
               address = await sdk.addresses.create(shippingAddressWithMeta)
               orderAttributes.shipping_address = sdk.addresses.relationship(


### PR DESCRIPTION
Closes #679 

## What I did

This PR will refresh the order when the addresses are updated in order to get taxes recalculated with new data.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
