### PR TITLE
Temporarily relax biome setup for v4

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,26 @@
         "noUnusedTemplateLiteral": "error",
         "useNumberNamespace": "error",
         "noInferrableTypes": "error",
-        "noUselessElse": "error"
+        "noUselessElse": "off"
+      },
+      "correctness": {
+        "useExhaustiveDependencies": "off",
+        "noUnusedVariables": "off",
+        "useParseIntRadix": "off",
+        "useUniqueElementIds": "off",
+        "noNestedComponentDefinitions": "off"
+      },
+      "complexity": {
+        "useLiteralKeys": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noArrayIndexKey": "off"
+      },
+      "a11y": {
+        "noStaticElementInteractions": "off",
+        "useKeyWithClickEvents": "off",
+        "noSvgWithoutTitle": "off"
       }
     }
   },

--- a/packages/react-components/src/components/addresses/AddressField.tsx
+++ b/packages/react-components/src/components/addresses/AddressField.tsx
@@ -73,7 +73,7 @@ export function AddressField(props: Props): JSX.Element {
   const { address } = useContext(AddressChildrenContext)
   const text = name && address ? address?.[name] : ""
   const { deleteCustomerAddress } = useContext(CustomerContext)
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.stopPropagation()
     e.preventDefault()
     if (type === "delete" && deleteCustomerAddress && address?.reference) {
@@ -92,9 +92,9 @@ export function AddressField(props: Props): JSX.Element {
       {text}
     </p>
   ) : (
-    <a data-testid={`address-field-${name ?? ""}`} {...p} onClick={handleClick}>
+    <button data-testid={`address-field-${name ?? ""}`} {...p} onClick={handleClick}>
       {label}
-    </a>
+    </button>
   )
 }
 

--- a/packages/react-components/src/components/line_items/LineItemRemoveLink.tsx
+++ b/packages/react-components/src/components/line_items/LineItemRemoveLink.tsx
@@ -13,7 +13,7 @@ interface ChildrenProps extends Omit<Props, 'children'> {
 }
 
 interface Props
-  extends PropsWithoutRef<Omit<JSX.IntrinsicElements['a'], 'children'>> {
+  extends PropsWithoutRef<Omit<JSX.IntrinsicElements['button'], 'children'>> {
   children?: ChildrenFunction<ChildrenProps>
   label?: string
 }
@@ -27,7 +27,7 @@ export function LineItemRemoveLink(props: Props): JSX.Element {
     key: 'lineItem'
   })
   const { deleteLineItem } = useContext(LineItemContext)
-  const handleRemove = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+  const handleRemove = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.preventDefault()
     if (deleteLineItem != null && lineItem != null)
       deleteLineItem(lineItem.id)
@@ -41,14 +41,14 @@ export function LineItemRemoveLink(props: Props): JSX.Element {
   return props.children ? (
     <Parent {...parentProps}>{props.children}</Parent>
   ) : (
-    <a
+    <button
       data-testid={`line-item-remove-link-${lineItem?.sku_code ?? ''}`}
       {...props}
-      href='#'
+      type='button'
       onClick={handleRemove}
     >
       {label}
-    </a>
+    </button>
   )
 }
 

--- a/packages/react-components/src/components/line_items/LineItemsContainer.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsContainer.tsx
@@ -65,10 +65,11 @@ export function LineItemsContainer(props: Props): JSX.Element {
   const lineItemValue: LineItemContextValue = {
     ...state,
     loader,
-    updateLineItem: async (lineItemId, quantity = 1, hasExternalPrice) => {
+    updateLineItem: async (lineItemId, quantity, hasExternalPrice) => {
+      const qty = quantity ?? 1
       await updateLineItem({
         lineItemId,
-        quantity,
+        quantity: qty,
         hasExternalPrice,
         dispatch,
         config,

--- a/packages/react-components/src/components/orders/AddToCartButton.tsx
+++ b/packages/react-components/src/components/orders/AddToCartButton.tsx
@@ -234,7 +234,8 @@ export function AddToCartButton(props: Props): JSX.Element {
         }
       }
       return res
-    } else if (url) {
+    }
+    if (url) {
       return await callExternalFunction({
         url,
         data: {

--- a/packages/react-components/src/components/orders/HostedCart.tsx
+++ b/packages/react-components/src/components/orders/HostedCart.tsx
@@ -155,10 +155,8 @@ export function HostedCart({
     key: 'accessToken'
   })
   const [src, setSrc] = useState<string | undefined>()
-  if (accessToken == null || endpoint == null) return null
   const { order, createOrder, getOrder } = useContext(OrderContext)
   const { persistKey } = useContext(OrderStorageContext)
-  const { domain, slug } = getDomain(endpoint)
   async function setOrder(openCart?: boolean): Promise<void> {
     const orderId = localStorage.getItem(persistKey) ?? (await createOrder({}))
     if (orderId != null && accessToken && endpoint) {
@@ -245,7 +243,8 @@ export function HostedCart({
     } else if (
       src == null &&
       (order?.id != null || orderId != null) &&
-      accessToken
+      accessToken &&
+      endpoint != null
     ) {
       getOrganizationConfig({
         accessToken,
@@ -274,7 +273,6 @@ export function HostedCart({
     return (): void => {
       ignore = true
       if (openAdd && type === 'mini') {
-        // biome-ignore lint/suspicious/noEmptyBlockStatements: <explanation>
         unsubscribe('open-cart', () => {})
       }
     }
@@ -290,6 +288,8 @@ export function HostedCart({
       ref.current
     )
   }, [ref.current != null])
+  if (accessToken == null || endpoint == null) return null
+  const { domain, slug } = getDomain(endpoint)
   /**
    * Close the cart.
    */
@@ -324,21 +324,22 @@ export function HostedCart({
         {...props}
       >
         <div style={{ ...defaultStyle.iconContainer, ...style?.iconContainer }}>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            fill='none'
-            viewBox='0 0 24 24'
-            strokeWidth={1.5}
-            stroke='currentColor'
-            style={{ ...defaultStyle.icon, ...style?.icon }}
-            onClick={onCloseCart}
-          >
-            <path
-              strokeLinecap='round'
-              strokeLinejoin='round'
-              d='M6 18L18 6M6 6l12 12'
-            />
-          </svg>
+          <button type="button" aria-label="Close cart" onClick={onCloseCart}>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              style={{ ...defaultStyle.icon, ...style?.icon }}
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M6 18L18 6M6 6l12 12'
+              />
+            </svg>
+          </button>
         </div>
         <iframe
           title='Cart'

--- a/packages/react-components/src/components/payment_source/AdyenPayment.tsx
+++ b/packages/react-components/src/components/payment_source/AdyenPayment.tsx
@@ -283,7 +283,6 @@ export function AdyenPayment({
         resultCode: controlCode,
       }
     }
-    // biome-ignore lint/suspicious/noExplicitAny: No types
     const attributes: any = {
       payment_request_data: {
         ...state.data,

--- a/packages/react-components/src/components/payment_source/PaymentSourceBrandIcon.tsx
+++ b/packages/react-components/src/components/payment_source/PaymentSourceBrandIcon.tsx
@@ -49,7 +49,7 @@ export function PaymentSourceBrandIcon({
   return children ? (
     <Parent {...parentProps}>{children}</Parent>
   ) : (
-    <img ref={ref} src={url} onError={handleError} width={width} {...p} />
+    <img alt={cardBrand ?? "credit card"} ref={ref} src={url} onError={handleError} width={width} {...p} />
   )
 }
 

--- a/packages/react-components/src/components/payment_source/StripePayment.tsx
+++ b/packages/react-components/src/components/payment_source/StripePayment.tsx
@@ -25,7 +25,6 @@ export interface StripeConfig {
   name?: string
   options?: StripePaymentElementOptions
   appearance?: StripeElementsOptions["appearance"]
-  // biome-ignore lint/suspicious/noExplicitAny: No type available
   [key: string]: any
 }
 

--- a/packages/react-components/src/components/shipping_methods/ShippingMethod.tsx
+++ b/packages/react-components/src/components/shipping_methods/ShippingMethod.tsx
@@ -12,7 +12,7 @@ export function ShippingMethod(props: Props): JSX.Element {
   const {
     children,
     readonly,
-    emptyText = `There are not any shipping method available`
+    emptyText = 'There are not any shipping method available'
   } = props
   const {
     shippingMethods,

--- a/packages/react-components/src/utils/isDate.ts
+++ b/packages/react-components/src/utils/isDate.ts
@@ -1,3 +1,3 @@
 export default function isDate(value: string): boolean {
-  return !isNaN(Date.parse(value))
+  return !Number.isNaN(Date.parse(value))
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Modified the `biome` setup to disable several rules and applied a little bunch of changes to the code to let the library raise a lower amount of linting errors.
The idea is that we are moving to a new major version of the library and we have not in plan to make big changes to the v4 version to avoid the need of refactoring and retesting a big amount of stuff that should be upgraded to fulfill the standard strict linting rules in a project that is going to be upgraded.

The PR is still not able to pass the biome checks because it is blocked by 8 final issues that I left to be checked together because they are related to some unused punctual ignore rules with comments by Ale that in case could be removed being actually covered by my updated permissive biome setup. I don't know if we care about the comments so I waited for your check to remove them.