### PR TITLE
✨ feat(PrivacyAndTermsCheckbox): fallback to org config for privacy_url and terms_url

### DIFF
--- a/packages/react-components/src/components/orders/PrivacyAndTermsCheckbox.tsx
+++ b/packages/react-components/src/components/orders/PrivacyAndTermsCheckbox.tsx
@@ -1,16 +1,24 @@
+import CommerceLayerContext from '#context/CommerceLayerContext'
 import OrderContext from '#context/OrderContext'
 import PlaceOrderContext from '#context/PlaceOrderContext'
+import { useOrganizationConfig } from '#utils/organization'
 import { useContext, useEffect, useState, type JSX } from 'react';
 import BaseInput, { type BaseInputProps } from '../utils/BaseInput'
 
 export function PrivacyAndTermsCheckbox(
   props: Partial<BaseInputProps>
 ): JSX.Element {
+  const { accessToken, endpoint } = useContext(CommerceLayerContext)
   const { order } = useContext(OrderContext)
   const { placeOrderPermitted } = useContext(PlaceOrderContext)
   const [forceDisabled, setForceDisabled] = useState(true)
   const [checked, setChecked] = useState(false)
   const fieldName = 'privacy-terms'
+  const organizationConfig = useOrganizationConfig({ accessToken, endpoint })
+
+  const privacyUrl = order?.privacy_url ?? organizationConfig?.urls?.privacy
+  const termsUrl = order?.terms_url ?? organizationConfig?.urls?.terms
+
   const handleChange: any = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const v = e.target?.checked
     setChecked(v)
@@ -18,13 +26,13 @@ export function PrivacyAndTermsCheckbox(
     if (placeOrderPermitted) placeOrderPermitted()
   }
   useEffect(() => {
-    if (order?.privacy_url && order?.terms_url) setForceDisabled(false)
+    if (privacyUrl && termsUrl) setForceDisabled(false)
     if (!checked) localStorage.setItem(fieldName, checked.toString())
     return () => {
       setForceDisabled(true)
       localStorage.removeItem(fieldName)
     }
-  }, [order?.privacy_url, order?.terms_url])
+  }, [privacyUrl, termsUrl])
   return (
     <BaseInput
       type='checkbox'

--- a/packages/react-components/src/components/orders/PrivacyAndTermsCheckbox.tsx
+++ b/packages/react-components/src/components/orders/PrivacyAndTermsCheckbox.tsx
@@ -1,25 +1,25 @@
-import CommerceLayerContext from '#context/CommerceLayerContext'
-import OrderContext from '#context/OrderContext'
-import PlaceOrderContext from '#context/PlaceOrderContext'
-import { useOrganizationConfig } from '#utils/organization'
-import { useContext, useEffect, useState, type JSX } from 'react';
-import BaseInput, { type BaseInputProps } from '../utils/BaseInput'
+import { type JSX, useContext, useEffect, useState } from "react"
+import CommerceLayerContext from "#context/CommerceLayerContext"
+import OrderContext from "#context/OrderContext"
+import PlaceOrderContext from "#context/PlaceOrderContext"
+import { useOrganizationConfig } from "#utils/organization"
+import BaseInput, { type BaseInputProps } from "../utils/BaseInput"
 
 export function PrivacyAndTermsCheckbox(
-  props: Partial<BaseInputProps>
+  props: Partial<BaseInputProps>,
 ): JSX.Element {
   const { accessToken, endpoint } = useContext(CommerceLayerContext)
   const { order } = useContext(OrderContext)
   const { placeOrderPermitted } = useContext(PlaceOrderContext)
   const [forceDisabled, setForceDisabled] = useState(true)
   const [checked, setChecked] = useState(false)
-  const fieldName = 'privacy-terms'
+  const fieldName = "privacy-terms"
   const organizationConfig = useOrganizationConfig({ accessToken, endpoint })
 
   const privacyUrl = order?.privacy_url ?? organizationConfig?.urls?.privacy
   const termsUrl = order?.terms_url ?? organizationConfig?.urls?.terms
 
-  const handleChange: any = (e: React.ChangeEvent<HTMLInputElement>): void => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const v = e.target?.checked
     setChecked(v)
     localStorage.setItem(fieldName, v.toString())
@@ -32,10 +32,10 @@ export function PrivacyAndTermsCheckbox(
       setForceDisabled(true)
       localStorage.removeItem(fieldName)
     }
-  }, [privacyUrl, termsUrl])
+  }, [privacyUrl, termsUrl, checked])
   return (
     <BaseInput
-      type='checkbox'
+      type="checkbox"
       name={fieldName}
       disabled={forceDisabled}
       onChange={handleChange}


### PR DESCRIPTION
## Summary

Implements a fallback to the organization configuration when `privacy_url` and `terms_url` are not set at the order level in `PrivacyAndTermsCheckbox`.

## Changes

- `PrivacyAndTermsCheckbox.tsx` now reads `accessToken` and `endpoint` from `CommerceLayerContext` and calls `useOrganizationConfig` to retrieve the MFE default config.
- `privacyUrl` and `termsUrl` are derived as `order?.privacy_url ?? organizationConfig?.urls?.privacy` (and same for terms), so the checkbox is enabled whenever the URLs are available from either source.
- The `useEffect` dependency array now tracks the derived URLs instead of the raw order fields.

## References

Closes #721  
Ref: https://github.com/commercelayer/mfe-checkout/issues/611