### PR TITLE
🐛 fix(HostedCart): refresh minicart URL when persistKey changes (#685)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.29.6",
+  "version": "4.29.7-beta.0",
   "command": {
     "version": {
       "preid": "beta"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.29.7-beta.2",
+  "version": "4.29.7-beta.3",
   "command": {
     "version": {
       "preid": "beta"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.29.7-beta.1",
+  "version": "4.29.7-beta.2",
   "command": {
     "version": {
       "preid": "beta"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.29.7-beta.3",
+  "version": "4.29.7-beta.4",
   "command": {
     "version": {
       "preid": "beta"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.29.7-beta.4",
+  "version": "4.29.7-beta.5",
   "command": {
     "version": {
       "preid": "beta"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "4.29.7-beta.0",
+  "version": "4.29.7-beta.1",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.29.6",
+  "version": "4.29.7-beta.0",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.29.7-beta.4",
+  "version": "4.29.7-beta.5",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.29.7-beta.3",
+  "version": "4.29.7-beta.4",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -200,7 +200,7 @@
   "homepage": "https://github.com/commercelayer/commercelayer-react-components#readme",
   "dependencies": {
     "@adyen/adyen-web": "^6.28.0",
-    "@commercelayer/organization-config": "^2.4.0",
+    "@commercelayer/organization-config": "^2.8.4",
     "@commercelayer/sdk": "^6.46.0",
     "@stripe/react-stripe-js": "^5.4.1",
     "@stripe/stripe-js": "^8.6.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.29.7-beta.1",
+  "version": "4.29.7-beta.2",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.29.7-beta.2",
+  "version": "4.29.7-beta.3",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "4.29.7-beta.0",
+  "version": "4.29.7-beta.1",
   "description": "The Official Commerce Layer React Components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/react-components/specs/orders/hosted-cart.spec.tsx
+++ b/packages/react-components/specs/orders/hosted-cart.spec.tsx
@@ -1,0 +1,96 @@
+import CommerceLayerContext from "#context/CommerceLayerContext"
+import OrderContext, { defaultOrderContext } from "#context/OrderContext"
+import OrderStorageContext from "#context/OrderStorageContext"
+import { HostedCart } from "#components/orders/HostedCart"
+import * as organizationUtils from "#utils/organization"
+import * as applicationLinkUtils from "#utils/getApplicationLink"
+import { render, waitFor } from "@testing-library/react"
+import { vi } from "vitest"
+
+vi.mock("iframe-resizer", () => ({
+  iframeResizer: vi.fn(),
+}))
+
+describe("HostedCart component", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it("updates minicart url when persistKey changes", async () => {
+    localStorage.setItem("cart-key-1", "order-id-1")
+    localStorage.setItem("cart-key-2", "order-id-2")
+
+    vi.spyOn(organizationUtils, "getOrganizationConfig").mockResolvedValue(null)
+
+    const getApplicationLinkSpy = vi
+      .spyOn(applicationLinkUtils, "getApplicationLink")
+      .mockImplementation(
+        ({ orderId }) => `https://test-cart.local/cart/${orderId}`,
+      )
+
+    const orderContextValue = {
+      ...defaultOrderContext,
+      createOrder: vi.fn().mockResolvedValue("created-order-id"),
+    }
+
+    const commonProps = {
+      clearWhenPlaced: true,
+      getLocalOrder: vi.fn(),
+      setLocalOrder: vi.fn(),
+      deleteLocalOrder: vi.fn(),
+    }
+
+    const { rerender } = render(
+      <CommerceLayerContext.Provider
+        value={{
+          accessToken: "test-token",
+          endpoint: "https://acme.commercelayer.io",
+        }}
+      >
+        <OrderContext.Provider value={orderContextValue}>
+          <OrderStorageContext.Provider
+            value={{
+              persistKey: "cart-key-1",
+              ...commonProps,
+            }}
+          >
+            <HostedCart />
+          </OrderStorageContext.Provider>
+        </OrderContext.Provider>
+      </CommerceLayerContext.Provider>,
+    )
+
+    await waitFor(() => {
+      expect(getApplicationLinkSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ orderId: "order-id-1" }),
+      )
+    })
+
+    rerender(
+      <CommerceLayerContext.Provider
+        value={{
+          accessToken: "test-token",
+          endpoint: "https://acme.commercelayer.io",
+        }}
+      >
+        <OrderContext.Provider value={orderContextValue}>
+          <OrderStorageContext.Provider
+            value={{
+              persistKey: "cart-key-2",
+              ...commonProps,
+            }}
+          >
+            <HostedCart />
+          </OrderStorageContext.Provider>
+        </OrderContext.Provider>
+      </CommerceLayerContext.Provider>,
+    )
+
+    await waitFor(() => {
+      expect(getApplicationLinkSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ orderId: "order-id-2" }),
+      )
+    })
+  })
+})

--- a/packages/react-components/src/components/customers/MyAccountLink.tsx
+++ b/packages/react-components/src/components/customers/MyAccountLink.tsx
@@ -1,4 +1,4 @@
-import { useContext, type JSX } from 'react';
+import { useContext, useEffect, useState, type JSX } from 'react';
 import Parent from '../utils/Parent'
 import type { ChildrenFunction } from '#typings/index'
 import CommerceLayerContext from '#context/CommerceLayerContext'
@@ -51,28 +51,13 @@ interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
 export function MyAccountLink(props: Props): JSX.Element {
   const { label = 'Go to my account', children, customDomain, returnUrl, ...p } = props
   const { accessToken, endpoint } = useContext(CommerceLayerContext)
+  const [href, setHref] = useState<string | undefined>(undefined)
   if (accessToken == null || endpoint == null)
     throw new Error('Cannot use `MyAccountLink` outside of `CommerceLayer`')
-  const { domain, slug } = getDomain(endpoint)
   const disabled = !('owner' in jwt(accessToken))
-  const href = getApplicationLink({
-    slug,
-    accessToken,
-    applicationType: 'my-account',
-    domain,
-    customDomain,
-    returnUrl
-  })
-  const parentProps = {
-    disabled,
-    label,
-    href,
-    ...p
-  }
-  function handleClick(
-    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
-  ): void {
-    if (!disabled && accessToken && endpoint) {
+  useEffect(() => {
+    if (accessToken && endpoint) {
+      const { domain, slug } = getDomain(endpoint)
       getOrganizationConfig({
         accessToken,
         endpoint,
@@ -83,16 +68,33 @@ export function MyAccountLink(props: Props): JSX.Element {
         }
       }).then((config) => {
         if (config?.links?.my_account) {
-          e.preventDefault()
-          location.href = config.links.my_account
+          setHref(config.links.my_account)
+        } else {
+          setHref(getApplicationLink({
+            slug,
+            accessToken,
+            applicationType: 'my-account',
+            domain,
+            customDomain,
+            returnUrl
+          }))
         }
       })
     }
+    return () => {
+      setHref(undefined)
+    }
+  }, [accessToken, endpoint, returnUrl, customDomain])
+  const parentProps = {
+    disabled,
+    label,
+    href,
+    ...p
   }
   return children ? (
     <Parent {...parentProps}>{children}</Parent>
   ) : (
-    <a aria-disabled={disabled} onClick={handleClick} href={href} {...p}>
+    <a aria-disabled={disabled} href={href} {...p}>
       {label}
     </a>
   )

--- a/packages/react-components/src/components/customers/MyAccountLink.tsx
+++ b/packages/react-components/src/components/customers/MyAccountLink.tsx
@@ -31,6 +31,11 @@ interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
    * The domain of your forked application
    */
   customDomain?: string
+  /**
+   * The return URL used by My Account to render the "back to store" link and the logout redirect.
+   * @link https://github.com/commercelayer/mfe-my-account?tab=readme-ov-file#back-to-shop-and-logout
+   */
+  returnUrl?: string
 }
 
 /**
@@ -44,7 +49,7 @@ interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
  * @link https://github.com/commercelayer/mfe-my-account
  */
 export function MyAccountLink(props: Props): JSX.Element {
-  const { label = 'Go to my account', children, customDomain, ...p } = props
+  const { label = 'Go to my account', children, customDomain, returnUrl, ...p } = props
   const { accessToken, endpoint } = useContext(CommerceLayerContext)
   if (accessToken == null || endpoint == null)
     throw new Error('Cannot use `MyAccountLink` outside of `CommerceLayer`')
@@ -55,7 +60,8 @@ export function MyAccountLink(props: Props): JSX.Element {
     accessToken,
     applicationType: 'my-account',
     domain,
-    customDomain
+    customDomain,
+    returnUrl
   })
   const parentProps = {
     disabled,
@@ -72,7 +78,8 @@ export function MyAccountLink(props: Props): JSX.Element {
         endpoint,
         params: {
           accessToken,
-          slug
+          slug,
+          returnUrl
         }
       }).then((config) => {
         if (config?.links?.my_account) {

--- a/packages/react-components/src/components/customers/MyIdentityLink.tsx
+++ b/packages/react-components/src/components/customers/MyIdentityLink.tsx
@@ -1,19 +1,19 @@
-import { useContext, useEffect, useState, type JSX } from 'react';
-import Parent from '../utils/Parent'
-import type { ChildrenFunction } from '#typings/index'
-import CommerceLayerContext from '#context/CommerceLayerContext'
-import { getApplicationLink } from '#utils/getApplicationLink'
-import { getDomain } from '#utils/getDomain'
-import { getOrganizationConfig } from '#utils/organization'
+import { type JSX, useContext, useEffect, useState } from "react"
+import CommerceLayerContext from "#context/CommerceLayerContext"
+import type { ChildrenFunction } from "#typings/index"
+import { getApplicationLink } from "#utils/getApplicationLink"
+import { getDomain } from "#utils/getDomain"
+import { getOrganizationConfig } from "#utils/organization"
+import Parent from "../utils/Parent"
 
-interface ChildrenProps extends Omit<Props, 'children'> {
+interface ChildrenProps extends Omit<Props, "children"> {
   /**
    * The link href
    */
   href: string
 }
 
-interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
+interface Props extends Omit<JSX.IntrinsicElements["a"], "children"> {
   /**
    * A render function to render your own custom component
    */
@@ -25,7 +25,7 @@ interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
   /**
    * The type of the link
    */
-  type: 'login' | 'signup'
+  type: "login" | "signup"
   /**
    * The client id of the Commerce Layer application
    */
@@ -78,17 +78,20 @@ export function MyIdentityLink(props: Props): JSX.Element {
   const { accessToken, endpoint } = useContext(CommerceLayerContext)
   const [href, setHref] = useState<string | undefined>(undefined)
   if (accessToken == null || endpoint == null)
-    throw new Error('Cannot use `MyIdentityLink` outside of `CommerceLayer`')
-  const { domain, slug } = getDomain(endpoint)
+    throw new Error("Cannot use `MyIdentityLink` outside of `CommerceLayer`")
   useEffect(() => {
     if (accessToken && endpoint) {
+      const { domain, slug } = getDomain(endpoint)
       getOrganizationConfig({
         accessToken,
         endpoint,
         params: {
           accessToken,
-          slug
-        }
+          slug,          identityType: type,
+          clientId,
+          scope,
+          returnUrl: returnUrl ?? window.location.href,
+          resetPasswordUrl,        },
       }).then((config) => {
         if (config?.links?.identity) {
           setHref(config.links.identity)
@@ -96,14 +99,14 @@ export function MyIdentityLink(props: Props): JSX.Element {
           const link = getApplicationLink({
             slug,
             accessToken,
-            applicationType: 'identity',
+            applicationType: "identity",
             domain,
             modeType: type,
             clientId,
             scope,
             returnUrl: returnUrl ?? window.location.href,
             resetPasswordUrl,
-            customDomain
+            customDomain,
           })
           setHref(link)
         }
@@ -112,14 +115,14 @@ export function MyIdentityLink(props: Props): JSX.Element {
     return () => {
       setHref(undefined)
     }
-  }, [accessToken, endpoint])
+  }, [accessToken, endpoint, type, clientId, scope, returnUrl, resetPasswordUrl, customDomain])
 
   const parentProps = {
     label,
     href,
     clientId,
     scope,
-    ...p
+    ...p,
   }
   return children ? (
     <Parent {...parentProps}>{children}</Parent>

--- a/packages/react-components/src/components/orders/AddToCartButton.tsx
+++ b/packages/react-components/src/components/orders/AddToCartButton.tsx
@@ -220,6 +220,8 @@ export function AddToCartButton(props: Props): JSX.Element {
               orderId,
               accessToken,
               slug,
+              skuListId,
+              skuId: sku?.id,
             },
           })
           location.href =

--- a/packages/react-components/src/components/orders/HostedCart.tsx
+++ b/packages/react-components/src/components/orders/HostedCart.tsx
@@ -1,20 +1,20 @@
+import type { Order } from "@commercelayer/sdk"
+import { iframeResizer } from "iframe-resizer"
+import {
+  type CSSProperties,
+  type JSX,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import CommerceLayerContext from "#context/CommerceLayerContext"
 import OrderContext from "#context/OrderContext"
 import OrderStorageContext from "#context/OrderStorageContext"
+import { subscribe, unsubscribe } from "#utils/events"
 import { getApplicationLink } from "#utils/getApplicationLink"
 import { getDomain } from "#utils/getDomain"
 import useCustomContext from "#utils/hooks/useCustomContext"
-import {
-  type CSSProperties,
-  useContext,
-  useEffect,
-  useState,
-  useRef,
-  type JSX,
-} from "react"
-import { iframeResizer } from "iframe-resizer"
-import type { Order } from "@commercelayer/sdk"
-import { subscribe, unsubscribe } from "#utils/events"
 import { getOrganizationConfig } from "#utils/organization"
 
 interface IframeData {
@@ -283,7 +283,6 @@ export function HostedCart({
     return (): void => {
       ignore = true
       if (openAdd && type === "mini") {
-        // biome-ignore lint/suspicious/noEmptyBlockStatements: <explanation>
         unsubscribe("open-cart", () => {})
       }
     }

--- a/packages/react-components/src/components/orders/HostedCart.tsx
+++ b/packages/react-components/src/components/orders/HostedCart.tsx
@@ -156,6 +156,7 @@ export function HostedCart({
   const [isOpen, setOpen] = useState(false)
   const ref = useRef<HTMLIFrameElement>(null)
   const loadedOrderIdRef = useRef<string | null>(null)
+  const prevOpenRef = useRef<boolean | undefined>(undefined)
   const { accessToken, endpoint } = useCustomContext({
     context: CommerceLayerContext,
     contextComponentName: "CommerceLayer",
@@ -223,24 +224,26 @@ export function HostedCart({
   useEffect(() => {
     const resolvedOrderId = order?.id ?? localStorage.getItem(persistKey)
     let ignore = false
-    if (open != null && open !== isOpen) {
+    if (open != null && prevOpenRef.current !== open) {
+      prevOpenRef.current = open
       setOpen(open)
     }
-    if (openAdd && type === "mini") {
-      subscribe("open-cart", () => {
-        window.document.body.style.overflow = "hidden"
-        if (src == null && resolvedOrderId == null) {
-          setOrder(true)
-        } else {
-          if (src != null && ref.current != null) {
-            ref.current.src = src
-          }
-          setTimeout(() => {
-            if (handleOpen != null) handleOpen()
-            else setOpen(true)
-          }, 300)
+    const openCartHandler = (): void => {
+      window.document.body.style.overflow = "hidden"
+      if (src == null && resolvedOrderId == null) {
+        setOrder(true)
+      } else {
+        if (src != null && ref.current != null) {
+          ref.current.src = src
         }
-      })
+        setTimeout(() => {
+          if (handleOpen != null) handleOpen()
+          else setOpen(true)
+        }, 300)
+      }
+    }
+    if (openAdd && type === "mini") {
+      subscribe("open-cart", openCartHandler)
     }
     if (
       src == null &&
@@ -283,7 +286,7 @@ export function HostedCart({
     return (): void => {
       ignore = true
       if (openAdd && type === "mini") {
-        unsubscribe("open-cart", () => {})
+        unsubscribe("open-cart", openCartHandler)
       }
     }
   }, [src, open, order?.id, accessToken, persistKey])
@@ -338,8 +341,14 @@ export function HostedCart({
             viewBox="0 0 24 24"
             strokeWidth={1.5}
             stroke="currentColor"
-            style={{ ...defaultStyle.icon, ...style?.icon }}
+            style={{ ...defaultStyle.icon, ...style?.icon, cursor: "pointer" }}
             onClick={onCloseCart}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                onCloseCart()
+              }
+            }}
+            aria-label="Close cart"
           >
             <path
               strokeLinecap="round"

--- a/packages/react-components/src/components/orders/HostedCart.tsx
+++ b/packages/react-components/src/components/orders/HostedCart.tsx
@@ -1,26 +1,33 @@
-import CommerceLayerContext from '#context/CommerceLayerContext'
-import OrderContext from '#context/OrderContext'
-import OrderStorageContext from '#context/OrderStorageContext'
-import { getApplicationLink } from '#utils/getApplicationLink'
-import { getDomain } from '#utils/getDomain'
-import useCustomContext from '#utils/hooks/useCustomContext'
-import { type CSSProperties, useContext, useEffect, useState, useRef, type JSX } from 'react';
-import { iframeResizer } from 'iframe-resizer'
-import type { Order } from '@commercelayer/sdk'
-import { subscribe, unsubscribe } from '#utils/events'
-import { getOrganizationConfig } from '#utils/organization'
+import CommerceLayerContext from "#context/CommerceLayerContext"
+import OrderContext from "#context/OrderContext"
+import OrderStorageContext from "#context/OrderStorageContext"
+import { getApplicationLink } from "#utils/getApplicationLink"
+import { getDomain } from "#utils/getDomain"
+import useCustomContext from "#utils/hooks/useCustomContext"
+import {
+  type CSSProperties,
+  useContext,
+  useEffect,
+  useState,
+  useRef,
+  type JSX,
+} from "react"
+import { iframeResizer } from "iframe-resizer"
+import type { Order } from "@commercelayer/sdk"
+import { subscribe, unsubscribe } from "#utils/events"
+import { getOrganizationConfig } from "#utils/organization"
 
 interface IframeData {
   message:
     | {
-        type: 'update'
+        type: "update"
         payload?: Order
       }
     | {
-        type: 'close'
+        type: "close"
       }
     | {
-        type: 'blur'
+        type: "blur"
       }
 }
 
@@ -33,50 +40,50 @@ interface Styles {
 }
 
 const defaultIframeStyle = {
-  width: '1px',
-  minWidth: '100%',
-  minHeight: '100%',
-  border: 'none',
-  paddingLeft: '20px',
-  paddingRight: '20px'
+  width: "1px",
+  minWidth: "100%",
+  minHeight: "100%",
+  border: "none",
+  paddingLeft: "20px",
+  paddingRight: "20px",
 } satisfies CSSProperties
 
 const defaultContainerStyle = {
-  position: 'fixed',
-  top: '0',
-  right: '-25rem',
-  height: '100%',
-  width: '23rem',
-  transition: 'right 0.5s ease-in-out',
+  position: "fixed",
+  top: "0",
+  right: "-25rem",
+  height: "100%",
+  width: "23rem",
+  transition: "right 0.5s ease-in-out",
   // zIndex: '0',
-  pointerEvents: 'none',
-  overflow: 'auto'
+  pointerEvents: "none",
+  overflow: "auto",
 } satisfies CSSProperties
 
 const defaultBackgroundStyle = {
-  opacity: '0',
-  position: 'fixed',
-  top: '0',
-  left: '0',
-  height: '100%',
-  width: '100vw',
-  transition: 'opacity 0.5s ease-in-out',
+  opacity: "0",
+  position: "fixed",
+  top: "0",
+  left: "0",
+  height: "100%",
+  width: "100vw",
+  transition: "opacity 0.5s ease-in-out",
   // zIndex: '-10',
-  pointerEvents: 'none',
-  backgroundColor: 'black'
+  pointerEvents: "none",
+  backgroundColor: "black",
 } satisfies CSSProperties
 
 const defaultIconStyle = {
-  width: '1.25rem',
-  height: '1.25rem'
+  width: "1.25rem",
+  height: "1.25rem",
 } satisfies CSSProperties
 
 const defaultIconContainer = {
-  textAlign: 'left',
-  paddingLeft: '20px',
-  paddingTop: '20px',
-  background: '#ffffff',
-  color: '#686E6E'
+  textAlign: "left",
+  paddingLeft: "20px",
+  paddingTop: "20px",
+  background: "#ffffff",
+  color: "#686E6E",
 } satisfies CSSProperties
 
 const defaultStyle = {
@@ -84,11 +91,11 @@ const defaultStyle = {
   container: defaultContainerStyle,
   background: defaultBackgroundStyle,
   icon: defaultIconStyle,
-  iconContainer: defaultIconContainer
+  iconContainer: defaultIconContainer,
 } satisfies Styles
 
 interface Props
-  extends Omit<JSX.IntrinsicElements['div'], 'children' | 'style'> {
+  extends Omit<JSX.IntrinsicElements["div"], "children" | "style"> {
   /**
    * The style of the cart.
    */
@@ -100,7 +107,7 @@ interface Props
   /**
    * The type of the cart. Defaults to undefined.
    */
-  type?: 'mini'
+  type?: "mini"
   /**
    * If true, the cart will open when a line item is added to the order clicking the add to cart button. Defaults to false.
    * Works only with the `type` prop set to `mini`.
@@ -148,11 +155,12 @@ export function HostedCart({
 }: Props): JSX.Element | null {
   const [isOpen, setOpen] = useState(false)
   const ref = useRef<HTMLIFrameElement>(null)
+  const loadedOrderIdRef = useRef<string | null>(null)
   const { accessToken, endpoint } = useCustomContext({
     context: CommerceLayerContext,
-    contextComponentName: 'CommerceLayer',
-    currentComponentName: 'HostedCart',
-    key: 'accessToken'
+    contextComponentName: "CommerceLayer",
+    currentComponentName: "HostedCart",
+    key: "accessToken",
   })
   const [src, setSrc] = useState<string | undefined>()
   if (accessToken == null || endpoint == null) return null
@@ -166,11 +174,12 @@ export function HostedCart({
         accessToken,
         endpoint,
         params: {
-          orderId: order?.id,
+          orderId: order?.id ?? orderId,
           accessToken,
-          slug
-        }
+          slug,
+        },
       })
+      loadedOrderIdRef.current = orderId
       setSrc(
         config?.links?.cart ??
           getApplicationLink({
@@ -178,9 +187,9 @@ export function HostedCart({
             orderId,
             accessToken,
             domain,
-            applicationType: 'cart',
-            customDomain
-          })
+            applicationType: "cart",
+            customDomain,
+          }),
       )
       if (openCart) {
         setTimeout(() => {
@@ -192,35 +201,35 @@ export function HostedCart({
   }
   function onMessage(data: IframeData): void {
     switch (data.message.type) {
-      case 'update':
+      case "update":
         if (data.message.payload != null) {
           getOrder(data.message.payload.id)
         }
         break
-      case 'close':
-        if (type === 'mini') {
+      case "close":
+        if (type === "mini") {
           if (handleOpen != null) handleOpen()
           else setOpen(false)
         }
         break
 
-      case 'blur':
-        if (type === 'mini' && isOpen) {
+      case "blur":
+        if (type === "mini" && isOpen) {
           ref.current?.focus()
         }
         break
     }
   }
   useEffect(() => {
-    const orderId = localStorage.getItem(persistKey)
+    const resolvedOrderId = order?.id ?? localStorage.getItem(persistKey)
     let ignore = false
     if (open != null && open !== isOpen) {
       setOpen(open)
     }
-    if (openAdd && type === 'mini') {
-      subscribe('open-cart', () => {
-        window.document.body.style.overflow = 'hidden'
-        if (src == null && order?.id == null && orderId == null) {
+    if (openAdd && type === "mini") {
+      subscribe("open-cart", () => {
+        window.document.body.style.overflow = "hidden"
+        if (src == null && resolvedOrderId == null) {
           setOrder(true)
         } else {
           if (src != null && ref.current != null) {
@@ -235,36 +244,36 @@ export function HostedCart({
     }
     if (
       src == null &&
-      order?.id == null &&
-      orderId == null &&
+      resolvedOrderId == null &&
       accessToken != null &&
       !ignore &&
       isOpen
     ) {
       setOrder()
     } else if (
-      src == null &&
-      (order?.id != null || orderId != null) &&
-      accessToken
+      resolvedOrderId != null &&
+      accessToken &&
+      (src == null || loadedOrderIdRef.current !== resolvedOrderId)
     ) {
       getOrganizationConfig({
         accessToken,
         endpoint,
         params: {
-          orderId: order?.id,
+          orderId: resolvedOrderId,
           accessToken,
-          slug
-        }
+          slug,
+        },
       }).then((config) => {
+        loadedOrderIdRef.current = resolvedOrderId
         setSrc(
           config?.links?.cart ??
             getApplicationLink({
               slug,
-              orderId: order?.id ?? orderId ?? '',
+              orderId: resolvedOrderId,
               accessToken,
               domain,
-              applicationType: 'cart'
-            })
+              applicationType: "cart",
+            }),
         )
       })
     }
@@ -273,42 +282,42 @@ export function HostedCart({
     }
     return (): void => {
       ignore = true
-      if (openAdd && type === 'mini') {
+      if (openAdd && type === "mini") {
         // biome-ignore lint/suspicious/noEmptyBlockStatements: <explanation>
-        unsubscribe('open-cart', () => {})
+        unsubscribe("open-cart", () => {})
       }
     }
-  }, [src, open, order?.id, accessToken])
+  }, [src, open, order?.id, accessToken, persistKey])
   useEffect(() => {
     if (ref.current == null) return
     iframeResizer(
       {
         checkOrigin: false,
         // @ts-expect-error No types available
-        onMessage
+        onMessage,
       },
-      ref.current
+      ref.current,
     )
   }, [ref.current != null])
   /**
    * Close the cart.
    */
   function onCloseCart(): void {
-    window.document.body.style.removeProperty('overflow')
+    window.document.body.style.removeProperty("overflow")
     if (handleOpen != null) handleOpen()
     else setOpen(false)
   }
-  return src == null ? null : type === 'mini' ? (
+  return src == null ? null : type === "mini" ? (
     <>
       <div
-        aria-hidden='true'
+        aria-hidden="true"
         style={{
           ...defaultStyle.background,
           ...style?.background,
-          opacity: isOpen ? '0.5' : defaultStyle.background?.opacity,
+          opacity: isOpen ? "0.5" : defaultStyle.background?.opacity,
           pointerEvents: isOpen
-            ? 'initial'
-            : defaultStyle.background?.pointerEvents
+            ? "initial"
+            : defaultStyle.background?.pointerEvents,
         }}
         onClick={onCloseCart}
       />
@@ -316,48 +325,48 @@ export function HostedCart({
         style={{
           ...defaultStyle.container,
           ...style?.container,
-          right: isOpen ? '0' : defaultStyle.container?.right,
+          right: isOpen ? "0" : defaultStyle.container?.right,
           pointerEvents: isOpen
-            ? 'initial'
-            : defaultStyle.container?.pointerEvents
+            ? "initial"
+            : defaultStyle.container?.pointerEvents,
         }}
         {...props}
       >
         <div style={{ ...defaultStyle.iconContainer, ...style?.iconContainer }}>
           <svg
-            xmlns='http://www.w3.org/2000/svg'
-            fill='none'
-            viewBox='0 0 24 24'
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
             strokeWidth={1.5}
-            stroke='currentColor'
+            stroke="currentColor"
             style={{ ...defaultStyle.icon, ...style?.icon }}
             onClick={onCloseCart}
           >
             <path
-              strokeLinecap='round'
-              strokeLinejoin='round'
-              d='M6 18L18 6M6 6l12 12'
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18L18 6M6 6l12 12"
             />
           </svg>
         </div>
         <iframe
-          title='Cart'
+          title="Cart"
           ref={ref}
           style={{ ...defaultStyle.cart, ...style?.cart }}
           src={src}
-          width='100%'
-          height='100%'
+          width="100%"
+          height="100%"
         />
       </div>
     </>
   ) : (
     <iframe
-      title='Cart'
+      title="Cart"
       ref={ref}
       style={{ ...defaultStyle.cart, ...style?.cart }}
       src={src}
-      width='100%'
-      height='100%'
+      width="100%"
+      height="100%"
     />
   )
 }

--- a/packages/react-components/src/utils/getApplicationLink.ts
+++ b/packages/react-components/src/utils/getApplicationLink.ts
@@ -60,7 +60,7 @@ export function getApplicationLink({
   const s = scope ? `&scope=${scope}` : ''
   const r = returnUrl ? `&returnUrl=${returnUrl}` : ''
   const p = resetPasswordUrl ? `&resetPasswordUrl=${resetPasswordUrl}` : ''
-  const params = applicationType === 'identity' ? `${c}${s}${r}${p}` : ''
+  const params = applicationType === 'identity' ? `${c}${s}${r}${p}` : applicationType === 'my-account' ? r : ''
   const domainName = customDomain ?? `${slug}.${env}commercelayer.app`
   const application = customDomain ? '' : `/${applicationType.toString()}`
   return `https://${domainName}${application}/${

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 9.1.7
       lerna:
         specifier: ^9.0.7
-        version: 9.0.7(@types/node@25.3.3)
+        version: 9.0.7(@types/node@25.5.2)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -101,7 +101,7 @@ importers:
         version: 7.6.21(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^7.6.17
-        version: 7.6.21(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.0)(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 7.6.21(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.0)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
@@ -116,7 +116,7 @@ importers:
         version: 18.3.28
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))
       babel-loader:
         specifier: ^9.2.1
         version: 9.2.1(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.25.12))
@@ -128,7 +128,7 @@ importers:
         version: 4.0.0
       msw:
         specifier: ^2.7.0
-        version: 2.12.10(@types/node@25.3.3)(typescript@5.9.3)
+        version: 2.12.10(@types/node@25.5.2)(typescript@5.9.3)
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -149,10 +149,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.1.0
-        version: 6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))
 
   packages/react-components:
     dependencies:
@@ -160,8 +160,8 @@ importers:
         specifier: ^6.28.0
         version: 6.31.0
       '@commercelayer/organization-config':
-        specifier: ^2.4.0
-        version: 2.7.0
+        specifier: ^2.8.4
+        version: 2.8.4
       '@commercelayer/sdk':
         specifier: ^6.46.0
         version: 6.52.0
@@ -234,10 +234,10 @@ importers:
         version: 1.8.8
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.4(vite@7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 5.1.4(vite@7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^4.0.16
-        version: 4.0.18(vitest@4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.2))
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0
@@ -267,13 +267,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: ^6.0.3
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.16
-        version: 4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.2)
 
 packages:
 
@@ -900,12 +900,12 @@ packages:
     resolution: {integrity: sha512-kk4VqN2iEOreXFq76YqTP83KhBs09Z5Ez9nZNlikXWf5DXzkrOfShqqEwq8ezHjSOlqs4xVyxgQzsEdPP35CeQ==}
     engines: {node: '>=18.0.0'}
 
-  '@commercelayer/js-auth@7.2.0':
-    resolution: {integrity: sha512-p6GLDsDz2C9I8Mq8bZtDhTqMPco2Vi7emuIy+sAWr1fEnu66JMwMi7hrM+NBMcEOnFAjYBh2B2R+1KZsp+bMTA==}
+  '@commercelayer/js-auth@7.3.0':
+    resolution: {integrity: sha512-o4HkMHqXqhPJ3gOA/61Na9T0ssLluV/SQEPtnb/N9/WpbiemEW43M1h/Iuc0/H8fSThqWe3Crt5HwGT5qAz6vQ==}
     engines: {node: '>=20.0.0'}
 
-  '@commercelayer/organization-config@2.7.0':
-    resolution: {integrity: sha512-rQx2UxluGZaQD6lKWtG/mv6aKN4sFN4TqmPhelRgf1Wena6NG6zzjrYTSJ42U2OhsfBt2ser/nPcQ/1NAQkuFA==}
+  '@commercelayer/organization-config@2.8.4':
+    resolution: {integrity: sha512-ZlgIhQx7vu89ZD3eOCSkCe7kNb5LgEGy0p4Gayi75sxfHfJRXKkoX2NC+nkp2pFosi4SBYhlQFcd/EtzStAQGw==}
     engines: {node: '>=18', pnpm: '>=7'}
 
   '@commercelayer/sdk@6.52.0':
@@ -2782,8 +2782,8 @@ packages:
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
-  '@types/node@25.3.3':
-    resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3664,8 +3664,8 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.20.0:
-    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.3.6:
@@ -6034,8 +6034,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
   tar-stream@2.2.0:
@@ -6049,8 +6049,8 @@ packages:
   telejson@7.2.0:
     resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
 
-  terser-webpack-plugin@5.3.17:
-    resolution: {integrity: sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==}
+  terser-webpack-plugin@5.4.0:
+    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -6065,8 +6065,8 @@ packages:
       uglify-js:
         optional: true
 
-  terser@5.46.0:
-    resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
+  terser@5.46.1:
+    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7460,11 +7460,11 @@ snapshots:
 
   '@commercelayer/js-auth@6.7.2': {}
 
-  '@commercelayer/js-auth@7.2.0': {}
+  '@commercelayer/js-auth@7.3.0': {}
 
-  '@commercelayer/organization-config@2.7.0':
+  '@commercelayer/organization-config@2.8.4':
     dependencies:
-      '@commercelayer/js-auth': 7.2.0
+      '@commercelayer/js-auth': 7.3.0
       merge-anything: 5.1.7
 
   '@commercelayer/sdk@6.52.0': {}
@@ -7689,15 +7689,15 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@25.3.3)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.5.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
   '@inquirer/confirm@5.1.21(@types/node@25.2.3)':
     dependencies:
@@ -7706,12 +7706,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
 
-  '@inquirer/confirm@5.1.21(@types/node@25.3.3)':
+  '@inquirer/confirm@5.1.21(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
   '@inquirer/core@10.3.2(@types/node@25.2.3)':
     dependencies:
@@ -7726,115 +7726,115 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
 
-  '@inquirer/core@10.3.2(@types/node@25.3.3)':
+  '@inquirer/core@10.3.2(@types/node@25.5.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/editor@4.2.23(@types/node@25.3.3)':
+  '@inquirer/editor@4.2.23(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/external-editor': 1.0.3(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/expand@4.0.23(@types/node@25.3.3)':
+  '@inquirer/expand@4.0.23(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.3.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.5.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@25.3.3)':
+  '@inquirer/input@4.3.1(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/number@3.0.23(@types/node@25.3.3)':
+  '@inquirer/number@3.0.23(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/password@4.0.23(@types/node@25.3.3)':
+  '@inquirer/password@4.0.23(@types/node@25.5.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/prompts@7.10.1(@types/node@25.3.3)':
+  '@inquirer/prompts@7.10.1(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@25.3.3)
-      '@inquirer/confirm': 5.1.21(@types/node@25.3.3)
-      '@inquirer/editor': 4.2.23(@types/node@25.3.3)
-      '@inquirer/expand': 4.0.23(@types/node@25.3.3)
-      '@inquirer/input': 4.3.1(@types/node@25.3.3)
-      '@inquirer/number': 3.0.23(@types/node@25.3.3)
-      '@inquirer/password': 4.0.23(@types/node@25.3.3)
-      '@inquirer/rawlist': 4.1.11(@types/node@25.3.3)
-      '@inquirer/search': 3.2.2(@types/node@25.3.3)
-      '@inquirer/select': 4.4.2(@types/node@25.3.3)
+      '@inquirer/checkbox': 4.3.2(@types/node@25.5.2)
+      '@inquirer/confirm': 5.1.21(@types/node@25.5.2)
+      '@inquirer/editor': 4.2.23(@types/node@25.5.2)
+      '@inquirer/expand': 4.0.23(@types/node@25.5.2)
+      '@inquirer/input': 4.3.1(@types/node@25.5.2)
+      '@inquirer/number': 3.0.23(@types/node@25.5.2)
+      '@inquirer/password': 4.0.23(@types/node@25.5.2)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.5.2)
+      '@inquirer/search': 3.2.2(@types/node@25.5.2)
+      '@inquirer/select': 4.4.2(@types/node@25.5.2)
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/rawlist@4.1.11(@types/node@25.3.3)':
+  '@inquirer/rawlist@4.1.11(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/search@3.2.2(@types/node@25.3.3)':
+  '@inquirer/search@3.2.2(@types/node@25.5.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
-  '@inquirer/select@4.4.2(@types/node@25.3.3)':
+  '@inquirer/select@4.4.2(@types/node@25.5.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
   '@inquirer/type@3.0.10(@types/node@25.2.3)':
     optionalDependencies:
       '@types/node': 25.2.3
 
-  '@inquirer/type@3.0.10(@types/node@25.3.3)':
+  '@inquirer/type@3.0.10(@types/node@25.5.2)':
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -7912,13 +7912,13 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -8938,7 +8938,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-vite@7.6.21(encoding@0.1.13)(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@storybook/builder-vite@7.6.21(encoding@0.1.13)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@storybook/channels': 7.6.21
       '@storybook/client-logger': 7.6.21
@@ -8956,7 +8956,7 @@ snapshots:
       fs-extra: 11.3.3
       magic-string: 0.30.21
       rollup: 4.60.0
-      vite: 6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9204,18 +9204,18 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-vite@7.6.21(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.0)(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@storybook/react-vite@7.6.21(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.0)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
-      '@storybook/builder-vite': 7.6.21(encoding@0.1.13)(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))
+      '@storybook/builder-vite': 7.6.21(encoding@0.1.13)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))
       '@storybook/react': 7.6.21(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@vitejs/plugin-react': 3.1.0(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))
+      '@vitejs/plugin-react': 3.1.0(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 7.1.1
       react-dom: 18.3.1(react@18.3.1)
-      vite: 6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -9518,7 +9518,7 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.3.3':
+  '@types/node@25.5.2':
     dependencies:
       undici-types: 7.18.2
 
@@ -9580,18 +9580,18 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitejs/plugin-react@3.1.0(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@3.1.0(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       magic-string: 0.27.0
       react-refresh: 0.14.2
-      vite: 6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -9599,11 +9599,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -9611,11 +9611,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -9627,7 +9627,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -9638,14 +9638,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@25.2.3)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -10472,10 +10472,10 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.20.0:
+  enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.2
 
   enquirer@2.3.6:
     dependencies:
@@ -11146,17 +11146,17 @@ snapshots:
 
   inject-stylesheet@7.0.0: {}
 
-  inquirer@12.9.6(@types/node@25.3.3):
+  inquirer@12.9.6(@types/node@25.5.2):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.3.3)
-      '@inquirer/prompts': 7.10.1(@types/node@25.3.3)
-      '@inquirer/type': 3.0.10(@types/node@25.3.3)
+      '@inquirer/core': 10.3.2(@types/node@25.5.2)
+      '@inquirer/prompts': 7.10.1(@types/node@25.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.5.2)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
 
   internal-slot@1.1.0:
     dependencies:
@@ -11402,7 +11402,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11502,7 +11502,7 @@ snapshots:
       dotenv: 16.6.1
       dotenv-expand: 10.0.0
 
-  lerna@9.0.7(@types/node@25.3.3):
+  lerna@9.0.7(@types/node@25.5.2):
     dependencies:
       '@npmcli/arborist': 9.1.6
       '@npmcli/package-json': 7.0.2
@@ -11533,7 +11533,7 @@ snapshots:
       import-local: 3.1.0
       ini: 1.3.8
       init-package-json: 8.2.2
-      inquirer: 12.9.6(@types/node@25.3.3)
+      inquirer: 12.9.6(@types/node@25.5.2)
       is-ci: 3.0.1
       jest-diff: 30.2.0
       js-yaml: 4.1.1
@@ -12191,9 +12191,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3):
+  msw@2.12.10(@types/node@25.5.2)(typescript@5.9.3):
     dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@25.3.3)
+      '@inquirer/confirm': 5.1.21(@types/node@25.5.2)
       '@mswjs/interceptors': 0.41.2
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -13347,7 +13347,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.2: {}
 
   tar-stream@2.2.0:
     dependencies:
@@ -13369,17 +13369,17 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  terser-webpack-plugin@5.3.17(esbuild@0.25.12)(webpack@5.105.2(esbuild@0.25.12)):
+  terser-webpack-plugin@5.4.0(esbuild@0.25.12)(webpack@5.105.2(esbuild@0.25.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.46.0
+      terser: 5.46.1
       webpack: 5.105.2(esbuild@0.25.12)
     optionalDependencies:
       esbuild: 0.25.12
 
-  terser@5.46.0:
+  terser@5.46.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
@@ -13666,28 +13666,28 @@ snapshots:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.1(@types/node@25.3.3)(terser@5.46.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@25.5.2)(terser@5.46.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13696,12 +13696,12 @@ snapshots:
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.2
       fsevents: 2.3.3
-      terser: 5.46.0
+      terser: 5.46.1
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13712,13 +13712,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
       fsevents: 2.3.3
-      terser: 5.46.0
+      terser: 5.46.1
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@25.2.3)(jsdom@27.4.0)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.1)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -13735,7 +13735,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.2.3)(terser@5.46.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.2.3
@@ -13792,7 +13792,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.0
+      enhanced-resolve: 5.20.1
       es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -13803,8 +13803,8 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.17(esbuild@0.25.12)(webpack@5.105.2(esbuild@0.25.12))
+      tapable: 2.3.2
+      terser-webpack-plugin: 5.4.0(esbuild@0.25.12)(webpack@5.105.2(esbuild@0.25.12))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:


### PR DESCRIPTION
## Changes

### 🐛 Fix: `HostedCart` — refresh minicart URL when `persistKey` changes (Closes #685)

- Added `loadedOrderIdRef` to track which order ID the current `src` was built for
- Added `persistKey` to `useEffect` dependency array so the cart URL recomputes when the storage key changes
- Fixed `setOrder` org-config lookup to use `order?.id ?? orderId` consistently
- Added regression test in `specs/orders/hosted-cart.spec.tsx`

### 📦 Deps: bump `@commercelayer/organization-config` to `^2.8.4`

- Updated from `^2.4.0` to `^2.8.4` to unlock new `ConfigParams` fields: `identityType`, `clientId`, `scope`, `returnUrl`, `resetPasswordUrl`, `skuListId`, `skuId`, `lang`, `token`

### ✨ Feat: `MyIdentityLink` — pass all identity params to `getOrganizationConfig`

- Forwards `identityType`, `clientId`, `scope`, `returnUrl`, `resetPasswordUrl` to `getOrganizationConfig`
- Moved `getDomain(endpoint)` inside the `useEffect` callback to keep deps clean
- Fixed `useEffect` dependency array to include all consumed props

### ✨ Feat: `AddToCartButton` — pass `skuListId` and `skuId` to `getOrganizationConfig`

- Forwards `skuListId` (from props) and `skuId` (from `SkuChildrenContext`) when resolving the cart URL on redirect, enabling org-config URL templates with `:sku_list_id` and `:sku_id` placeholders to resolve correctly

### ♻️ Refactor: `HostedCart` — resolve order ID once via `resolvedOrderId`

- Extracted `order?.id ?? localStorage.getItem(persistKey)` into a single `resolvedOrderId` variable at the top of the effect

### 🐛 Fix: `MyAccountLink` — add `returnUrl` prop (Closes #687)

- Added `returnUrl?: string` prop to enable the "back to store" link and logout redirect in mfe-my-account
- Passed to `getApplicationLink()` for the static `href`
- Passed via `getOrganizationConfig` params so `getMfeConfig` includes it in `config.links.my_account` — following the same pattern as `MyIdentityLink`

---

## 🐛 Fix: HostedCart — minicart glitch on first visit (Closes #686)

**Root cause**: On first visit with no orderId, `createOrder()` is async. After the cart was opened via `setOpen(true)` (300ms timer), if `order?.id` updated in context afterward, the effect re-ran and `open=false, isOpen=true` triggered `setOpen(false)`, closing the cart.

**Fixes**:
- Added `prevOpenRef` to only call `setOpen` when the `open` prop itself changes, not on unrelated effect re-runs
- Fixed subscription leak: `unsubscribe("open-cart", () => {})` was passing a new anonymous function so the listener was never removed; now uses a named `openCartHandler` shared by both `subscribe` and `unsubscribe`

---

## ♻️ Refactor: MyAccountLink — useEffect pattern (like MyIdentityLink)

Replace synchronous `href` + `onClick` handler with a `useEffect` that resolves org config on mount and sets `href` via state, falling back to `getApplicationLink` when no org config link is available.