### PR TITLE
fix(MyAccountLink): add returnUrl prop + fix HostedCart minicart glitch

### DIFF
--- a/packages/react-components/src/components/customers/MyAccountLink.tsx
+++ b/packages/react-components/src/components/customers/MyAccountLink.tsx
@@ -1,4 +1,4 @@
-import { useContext, type JSX } from 'react';
+import { useContext, useEffect, useState, type JSX } from 'react';
 import Parent from '../utils/Parent'
 import type { ChildrenFunction } from '#typings/index'
 import CommerceLayerContext from '#context/CommerceLayerContext'
@@ -51,28 +51,13 @@ interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
 export function MyAccountLink(props: Props): JSX.Element {
   const { label = 'Go to my account', children, customDomain, returnUrl, ...p } = props
   const { accessToken, endpoint } = useContext(CommerceLayerContext)
+  const [href, setHref] = useState<string | undefined>(undefined)
   if (accessToken == null || endpoint == null)
     throw new Error('Cannot use `MyAccountLink` outside of `CommerceLayer`')
-  const { domain, slug } = getDomain(endpoint)
   const disabled = !('owner' in jwt(accessToken))
-  const href = getApplicationLink({
-    slug,
-    accessToken,
-    applicationType: 'my-account',
-    domain,
-    customDomain,
-    returnUrl
-  })
-  const parentProps = {
-    disabled,
-    label,
-    href,
-    ...p
-  }
-  function handleClick(
-    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
-  ): void {
-    if (!disabled && accessToken && endpoint) {
+  useEffect(() => {
+    if (accessToken && endpoint) {
+      const { domain, slug } = getDomain(endpoint)
       getOrganizationConfig({
         accessToken,
         endpoint,
@@ -83,16 +68,33 @@ export function MyAccountLink(props: Props): JSX.Element {
         }
       }).then((config) => {
         if (config?.links?.my_account) {
-          e.preventDefault()
-          location.href = config.links.my_account
+          setHref(config.links.my_account)
+        } else {
+          setHref(getApplicationLink({
+            slug,
+            accessToken,
+            applicationType: 'my-account',
+            domain,
+            customDomain,
+            returnUrl
+          }))
         }
       })
     }
+    return () => {
+      setHref(undefined)
+    }
+  }, [accessToken, endpoint, returnUrl, customDomain])
+  const parentProps = {
+    disabled,
+    label,
+    href,
+    ...p
   }
   return children ? (
     <Parent {...parentProps}>{children}</Parent>
   ) : (
-    <a aria-disabled={disabled} onClick={handleClick} href={href} {...p}>
+    <a aria-disabled={disabled} href={href} {...p}>
       {label}
     </a>
   )

--- a/packages/react-components/src/components/customers/MyAccountLink.tsx
+++ b/packages/react-components/src/components/customers/MyAccountLink.tsx
@@ -31,6 +31,11 @@ interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
    * The domain of your forked application
    */
   customDomain?: string
+  /**
+   * The return URL used by My Account to render the "back to store" link and the logout redirect.
+   * @link https://github.com/commercelayer/mfe-my-account?tab=readme-ov-file#back-to-shop-and-logout
+   */
+  returnUrl?: string
 }
 
 /**
@@ -44,7 +49,7 @@ interface Props extends Omit<JSX.IntrinsicElements['a'], 'children'> {
  * @link https://github.com/commercelayer/mfe-my-account
  */
 export function MyAccountLink(props: Props): JSX.Element {
-  const { label = 'Go to my account', children, customDomain, ...p } = props
+  const { label = 'Go to my account', children, customDomain, returnUrl, ...p } = props
   const { accessToken, endpoint } = useContext(CommerceLayerContext)
   if (accessToken == null || endpoint == null)
     throw new Error('Cannot use `MyAccountLink` outside of `CommerceLayer`')
@@ -55,7 +60,8 @@ export function MyAccountLink(props: Props): JSX.Element {
     accessToken,
     applicationType: 'my-account',
     domain,
-    customDomain
+    customDomain,
+    returnUrl
   })
   const parentProps = {
     disabled,
@@ -72,7 +78,8 @@ export function MyAccountLink(props: Props): JSX.Element {
         endpoint,
         params: {
           accessToken,
-          slug
+          slug,
+          returnUrl
         }
       }).then((config) => {
         if (config?.links?.my_account) {

--- a/packages/react-components/src/components/orders/HostedCart.tsx
+++ b/packages/react-components/src/components/orders/HostedCart.tsx
@@ -156,6 +156,7 @@ export function HostedCart({
   const [isOpen, setOpen] = useState(false)
   const ref = useRef<HTMLIFrameElement>(null)
   const loadedOrderIdRef = useRef<string | null>(null)
+  const prevOpenRef = useRef<boolean | undefined>(undefined)
   const { accessToken, endpoint } = useCustomContext({
     context: CommerceLayerContext,
     contextComponentName: "CommerceLayer",
@@ -223,24 +224,26 @@ export function HostedCart({
   useEffect(() => {
     const resolvedOrderId = order?.id ?? localStorage.getItem(persistKey)
     let ignore = false
-    if (open != null && open !== isOpen) {
+    if (open != null && prevOpenRef.current !== open) {
+      prevOpenRef.current = open
       setOpen(open)
     }
-    if (openAdd && type === "mini") {
-      subscribe("open-cart", () => {
-        window.document.body.style.overflow = "hidden"
-        if (src == null && resolvedOrderId == null) {
-          setOrder(true)
-        } else {
-          if (src != null && ref.current != null) {
-            ref.current.src = src
-          }
-          setTimeout(() => {
-            if (handleOpen != null) handleOpen()
-            else setOpen(true)
-          }, 300)
+    const openCartHandler = (): void => {
+      window.document.body.style.overflow = "hidden"
+      if (src == null && resolvedOrderId == null) {
+        setOrder(true)
+      } else {
+        if (src != null && ref.current != null) {
+          ref.current.src = src
         }
-      })
+        setTimeout(() => {
+          if (handleOpen != null) handleOpen()
+          else setOpen(true)
+        }, 300)
+      }
+    }
+    if (openAdd && type === "mini") {
+      subscribe("open-cart", openCartHandler)
     }
     if (
       src == null &&
@@ -283,7 +286,7 @@ export function HostedCart({
     return (): void => {
       ignore = true
       if (openAdd && type === "mini") {
-        unsubscribe("open-cart", () => {})
+        unsubscribe("open-cart", openCartHandler)
       }
     }
   }, [src, open, order?.id, accessToken, persistKey])
@@ -338,8 +341,14 @@ export function HostedCart({
             viewBox="0 0 24 24"
             strokeWidth={1.5}
             stroke="currentColor"
-            style={{ ...defaultStyle.icon, ...style?.icon }}
+            style={{ ...defaultStyle.icon, ...style?.icon, cursor: "pointer" }}
             onClick={onCloseCart}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                onCloseCart()
+              }
+            }}
+            aria-label="Close cart"
           >
             <path
               strokeLinecap="round"

--- a/packages/react-components/src/utils/getApplicationLink.ts
+++ b/packages/react-components/src/utils/getApplicationLink.ts
@@ -60,7 +60,7 @@ export function getApplicationLink({
   const s = scope ? `&scope=${scope}` : ''
   const r = returnUrl ? `&returnUrl=${returnUrl}` : ''
   const p = resetPasswordUrl ? `&resetPasswordUrl=${resetPasswordUrl}` : ''
-  const params = applicationType === 'identity' ? `${c}${s}${r}${p}` : ''
+  const params = applicationType === 'identity' ? `${c}${s}${r}${p}` : applicationType === 'my-account' ? r : ''
   const domainName = customDomain ?? `${slug}.${env}commercelayer.app`
   const application = customDomain ? '' : `/${applicationType.toString()}`
   return `https://${domainName}${application}/${


### PR DESCRIPTION
## Changes

Backport of fixes from #740 onto `v5.0.0`.

### 🐛 Fix: MyAccountLink — add `returnUrl` prop (Closes #687)
Adds `returnUrl?: string` prop to `MyAccountLink`. Passes it through `getOrganizationConfig` params so mfe-my-account can render the "back to store" link and handle logout redirect.

### 🐛 Fix: HostedCart — minicart glitch on first visit (Closes #686)
On first visit with no orderId, the minicart was opening and closing immediately due to a race condition with `createOrder()`. Fixed with `prevOpenRef` to only call `setOpen` when the `open` prop itself changes. Also fixed subscription leak in `unsubscribe`.

### ♻️ Refactor: MyAccountLink — useEffect pattern (like MyIdentityLink)
Replace synchronous `href` + `onClick` with a `useEffect` that resolves org config on mount, falling back to `getApplicationLink`.