### PR TITLE
📚 docs(stories): extract deprecated containers into own story files

### DIFF
--- a/packages/document/src/stories/availability/AvailabilityContainer.stories.tsx
+++ b/packages/document/src/stories/availability/AvailabilityContainer.stories.tsx
@@ -1,0 +1,106 @@
+import {
+  Availability,
+  AvailabilityContainer,
+  AvailabilityTemplate,
+} from "@commercelayer/react-components"
+import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import CommerceLayer from "../_internals/CommerceLayer"
+
+function AvailabilityContainerDocsPage(): JSX.Element {
+  return (
+    <>
+      <h1>AvailabilityContainer</h1>
+      <span title="Deprecated" type="warning">
+        <p>
+          <code>{"<AvailabilityContainer>"}</code> is deprecated. Use the standalone{" "}
+          <code>{"<Availability skuCode='...'>"}</code> component instead. See{" "}
+          <strong>Availability/Availability</strong> for the recommended pattern.{" "}
+          <code>{"<AvailabilityContainer>"}</code> will be removed in the next major version.
+        </p>
+      </span>
+      <p>
+        <code>{"<AvailabilityContainer>"}</code> fetches inventory data for a given SKU code and
+        makes it available to its <code>{"<AvailabilityTemplate>"}</code> children via context.
+      </p>
+      <ArgTypes />
+      <hr />
+      <h2>Migration guide</h2>
+      <p>
+        <strong>Before (deprecated):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, AvailabilityContainer, AvailabilityTemplate } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="...">
+  <AvailabilityContainer skuCode="TSHIRTMM000000FFFFFFXLXX">
+    <AvailabilityTemplate />
+  </AvailabilityContainer>
+</CommerceLayer>
+`}
+      />
+      <p>
+        <strong>After (recommended):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, Availability, AvailabilityTemplate } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="...">
+  <Availability skuCode="TSHIRTMM000000FFFFFFXLXX">
+    <AvailabilityTemplate />
+  </Availability>
+</CommerceLayer>
+`}
+      />
+      <hr />
+      <h2>Example</h2>
+      <Canvas of={DeprecatedContainer} />
+    </>
+  )
+}
+
+const meta = {
+  title: "Components/Availability/AvailabilityContainer",
+  component: AvailabilityContainer,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: AvailabilityContainerDocsPage,
+    },
+  },
+  argTypes: {
+    skuCode: {
+      control: "text",
+      description: "The SKU code to fetch availability for.",
+    },
+    skuId: {
+      control: "text",
+      description:
+        "The SKU resource ID. Takes precedence over `skuCode` and improves performance by skipping the code-to-id lookup.",
+    },
+    children: {
+      control: false,
+      description: "Accepts `<AvailabilityTemplate>` as a child.",
+    },
+  },
+} satisfies Meta<typeof AvailabilityContainer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const DeprecatedContainer: Story = {
+  name: "AvailabilityContainer — deprecated (legacy)",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <AvailabilityContainer skuCode="POLOMXXX000000FFFFFFLXXX">
+        <AvailabilityTemplate />
+      </AvailabilityContainer>
+    </CommerceLayer>
+  ),
+}

--- a/packages/document/src/stories/availability/AvailabilityTemplate.stories.tsx
+++ b/packages/document/src/stories/availability/AvailabilityTemplate.stories.tsx
@@ -1,0 +1,278 @@
+import {
+  Availability,
+  AvailabilityTemplate,
+} from "@commercelayer/react-components"
+import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import CommerceLayer from "../_internals/CommerceLayer"
+
+function AvailabilityTemplateDocsPage(): JSX.Element {
+  return (
+    <>
+      <h1>AvailabilityTemplate</h1>
+      <p>
+        Reads from the parent <code>{"<Availability>"}</code> context and renders a{" "}
+        <code>{"<span>"}</code> with availability text. Customise the label shown for each state (
+        <code>available</code>, <code>outOfStock</code>, <code>negativeStock</code>) and optionally
+        include delivery lead time and shipping method details.
+      </p>
+      <blockquote>
+        <p>
+          Must be a descendant of the <code>{"<Availability>"}</code> component.
+        </p>
+      </blockquote>
+      <ArgTypes />
+      <table>
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>labels.available</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>"Available"</code>
+            </td>
+            <td>Text shown when quantity &gt; 0</td>
+          </tr>
+          <tr>
+            <td>
+              <code>labels.outOfStock</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>"Out of stock"</code>
+            </td>
+            <td>Text shown when quantity is 0</td>
+          </tr>
+          <tr>
+            <td>
+              <code>labels.negativeStock</code>
+            </td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>"Not available"</code>
+            </td>
+            <td>Text shown when quantity is negative</td>
+          </tr>
+          <tr>
+            <td>
+              <code>timeFormat</code>
+            </td>
+            <td>
+              <code>"days" | "hours"</code>
+            </td>
+            <td>—</td>
+            <td>When set, delivery lead time is appended to the label</td>
+          </tr>
+          <tr>
+            <td>
+              <code>showShippingMethodName</code>
+            </td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>
+              <code>false</code>
+            </td>
+            <td>
+              Requires <code>timeFormat</code>. Appends the shipping method name
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>showShippingMethodPrice</code>
+            </td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>
+              <code>false</code>
+            </td>
+            <td>
+              Requires <code>timeFormat</code>. Appends the formatted shipping price
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <hr />
+      <h2>Custom labels</h2>
+      <p>
+        Customise the displayed text for all stock states via the <code>labels</code> prop.
+      </p>
+      <Canvas of={CustomLabels} />
+      <h2>Lead time</h2>
+      <p>
+        Set <code>timeFormat</code> to <code>"days"</code> or <code>"hours"</code> to show the
+        shipping lead time alongside the availability status.
+      </p>
+      <Canvas of={WithDeliveryLeadTimeDays} />
+      <Canvas of={WithDeliveryLeadTimeHours} />
+      <h2>Shipping method</h2>
+      <Canvas of={WithShippingMethodName} />
+      <Canvas of={WithShippingMethodPrice} />
+      <hr />
+      <h2>Children render prop</h2>
+      <p>
+        Pass a function as <code>children</code> to fully control the rendered output. The function
+        receives the full availability context including <code>quantity</code>, <code>text</code>,{" "}
+        <code>min</code>, <code>max</code>, and <code>shipping_method</code>.
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+<Availability skuCode="TSHIRTMM000000FFFFFFXLXX">
+  <AvailabilityTemplate>
+    {({ quantity, text, min, max }) => (
+      <div>
+        <strong>{text}</strong>
+        {quantity > 0 && min != null && (
+          <p>Ships in {min.days}–{max?.days ?? min.days} days</p>
+        )}
+      </div>
+    )}
+  </AvailabilityTemplate>
+</Availability>
+`}
+      />
+      <Canvas of={WithChildrenRenderProp} />
+    </>
+  )
+}
+
+const meta = {
+  title: "Components/Availability/AvailabilityTemplate",
+  component: AvailabilityTemplate,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: AvailabilityTemplateDocsPage,
+    },
+  },
+  argTypes: {
+    labels: {
+      control: "object",
+      description:
+        "Text labels for each stock state: `available`, `outOfStock`, `negativeStock`.",
+    },
+    timeFormat: {
+      control: "select",
+      options: ["days", "hours"],
+      description:
+        "When set, delivery lead time is appended to the availability label.",
+    },
+    showShippingMethodName: {
+      control: "boolean",
+      description: "Requires `timeFormat`. Appends the shipping method name to the label.",
+    },
+    showShippingMethodPrice: {
+      control: "boolean",
+      description: "Requires `timeFormat`. Appends the formatted shipping price to the label.",
+    },
+    children: {
+      control: false,
+      description:
+        "Render prop receiving `{ quantity, text, min, max, shipping_method }` for a fully custom availability UI.",
+    },
+  },
+} satisfies Meta<typeof AvailabilityTemplate>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const CustomLabels: Story = {
+  name: "AvailabilityTemplate — custom labels",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
+        <AvailabilityTemplate
+          labels={{
+            available: "✅ In stock",
+            outOfStock: "❌ Sold out",
+            negativeStock: "⚠️ Not available",
+          }}
+        />
+      </Availability>
+    </CommerceLayer>
+  ),
+}
+
+export const WithDeliveryLeadTimeDays: Story = {
+  name: "AvailabilityTemplate — lead time in days",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
+        <AvailabilityTemplate labels={{ available: "Available" }} timeFormat="days" />
+      </Availability>
+    </CommerceLayer>
+  ),
+}
+
+export const WithDeliveryLeadTimeHours: Story = {
+  name: "AvailabilityTemplate — lead time in hours",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
+        <AvailabilityTemplate labels={{ available: "Available" }} timeFormat="hours" />
+      </Availability>
+    </CommerceLayer>
+  ),
+}
+
+export const WithShippingMethodName: Story = {
+  name: "AvailabilityTemplate — with shipping method name",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
+        <AvailabilityTemplate timeFormat="days" showShippingMethodName />
+      </Availability>
+    </CommerceLayer>
+  ),
+}
+
+export const WithShippingMethodPrice: Story = {
+  name: "AvailabilityTemplate — with shipping method price",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
+        <AvailabilityTemplate timeFormat="days" showShippingMethodName showShippingMethodPrice />
+      </Availability>
+    </CommerceLayer>
+  ),
+}
+
+export const WithChildrenRenderProp: Story = {
+  name: "AvailabilityTemplate — children render prop",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
+        <AvailabilityTemplate>
+          {({ quantity, text, min, max }) => (
+            <div style={{ fontFamily: "monospace", fontSize: 14 }}>
+              <strong>{text}</strong>
+              {quantity > 0 && min != null && (
+                <p style={{ marginTop: 4, color: "#666" }}>
+                  Ships in {min.days}–{max?.days ?? min.days} day(s)
+                </p>
+              )}
+            </div>
+          )}
+        </AvailabilityTemplate>
+      </Availability>
+    </CommerceLayer>
+  ),
+}

--- a/packages/document/src/stories/availability/availability.stories.tsx
+++ b/packages/document/src/stories/availability/availability.stories.tsx
@@ -1,6 +1,5 @@
 import {
   Availability,
-  AvailabilityContainer,
   AvailabilityTemplate,
   Sku,
   SkuField,
@@ -14,19 +13,20 @@ function AvailabilityDocsPage(): JSX.Element {
     <>
       <h1>Availability</h1>
       <p>
-        The Availability components display real-time stock and shipping
-        information for a SKU. Use the standalone{" "}
-        <code>{"<Availability>"}</code> component (recommended) — it fetches
-        availability data automatically. The legacy{" "}
-        <code>{"<AvailabilityContainer>"}</code> is kept for backwards
-        compatibility.
+        The Availability components let you display real-time stock quantity and
+        delivery lead times for any SKU. They are powered by the Commerce Layer
+        inventory model and work by fetching availability data through the{" "}
+        <code>useAvailability</code> hook from <code>@commercelayer/hooks</code>
+        . All Availability components must be nested inside the{" "}
+        <code>{"<CommerceLayer>"}</code> context.
       </p>
       <hr />
-      <h2>Availability</h2>
+      <h2>Availability (standalone)</h2>
       <p>
-        Standalone component that fetches availability without any container.
-        Picks up <code>skuCode</code> from a parent <code>{"<Sku>"}</code> or
-        line-item context when no prop is given.
+        The preferred way to display availability.{" "}
+        <code>{"<Availability>"}</code> fetches inventory data on its own — no
+        container wrapper needed. Picks up <code>skuCode</code> from a parent{" "}
+        <code>{"<Sku>"}</code> or line-item context when no prop is given.
       </p>
       <blockquote>
         <p>
@@ -42,65 +42,60 @@ function AvailabilityDocsPage(): JSX.Element {
 import { CommerceLayer, Availability, AvailabilityTemplate } from '@commercelayer/react-components'
 
 <CommerceLayer accessToken="..." endpoint="https://yourdomain.commercelayer.io">
-  <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
-    <AvailabilityTemplate
-      labels={{ available: "In stock", outOfStock: "Out of stock" }}
-    />
+  <Availability skuCode="TSHIRTMM000000FFFFFFXLXX">
+    <AvailabilityTemplate labels={{ available: 'In stock', outOfStock: 'Out of stock' }} />
   </Availability>
 </CommerceLayer>
 `}
       />
       <Canvas of={StandaloneAvailability} />
       <hr />
-      <h2>AvailabilityTemplate — custom labels</h2>
+      <h2>Usage inside Skus</h2>
       <p>
-        Customise the displayed text for all stock states via the{" "}
-        <code>labels</code> prop.
-      </p>
-      <Canvas of={CustomLabels} />
-      <hr />
-      <h2>Lead time</h2>
-      <p>
-        Set <code>timeFormat</code> to <code>"days"</code> or{" "}
-        <code>"hours"</code> to show the shipping lead time alongside the
-        availability status.
-      </p>
-      <Canvas of={WithDeliveryLeadTimeDays} />
-      <hr />
-      <h2>Children render prop</h2>
-      <p>
-        Pass a function as <code>children</code> to{" "}
-        <code>{"<AvailabilityTemplate>"}</code> to receive the raw data (
-        <code>quantity</code>, <code>text</code>, <code>min</code>,{" "}
-        <code>max</code>) and build a custom UI.
-      </p>
-      <Canvas of={WithChildrenRenderProp} />
-      <hr />
-      <h2>Inside Sku (inherits skuCode)</h2>
-      <p>
-        When <code>{"<Availability>"}</code> is nested inside{" "}
-        <code>{"<Sku>"}</code>, the <code>skuCode</code> prop can be omitted —
-        it is inherited from the context automatically.
+        When used inside a <code>{"<Sku>"}</code> or{" "}
+        <code>{"<SkusContainer>"}</code> → <code>{"<Skus>"}</code> tree,{" "}
+        <code>{"<Availability>"}</code> automatically inherits the{" "}
+        <code>skuCode</code> from the current SKU context — no need to pass{" "}
+        <code>skuCode</code> explicitly.
       </p>
       <Canvas of={InsideSku} />
-      <hr />
-      <h2>AvailabilityContainer (deprecated)</h2>
-      <p>
-        <code>{"<AvailabilityContainer>"}</code> is the legacy wrapper. Prefer{" "}
-        the standalone <code>{"<Availability>"}</code> component for new code.
-      </p>
-      <Canvas of={DeprecatedContainer} />
     </>
   )
 }
 
 const meta = {
-  title: "Availability/Availability",
+  title: "Components/Availability/Availability",
   component: Availability,
   parameters: {
     layout: "centered",
     docs: {
       page: AvailabilityDocsPage,
+    },
+  },
+  argTypes: {
+    skuCode: {
+      control: "text",
+      description:
+        "The SKU code to fetch availability for. Automatically inherited from a parent `<Sku>` or line-item context when omitted.",
+    },
+    skuId: {
+      control: "text",
+      description:
+        "The SKU resource ID. Takes precedence over `skuCode` and improves performance by skipping the code-to-id lookup.",
+    },
+    getQuantity: {
+      control: false,
+      description:
+        "Callback fired whenever the available quantity changes. Receives the quantity as a number.",
+    },
+    loader: {
+      control: "text",
+      description: "Content displayed while availability data is loading.",
+    },
+    children: {
+      control: false,
+      description:
+        "Accepts `<AvailabilityTemplate>` as a child to display stock status and lead time.",
     },
   },
 } satisfies Meta<typeof Availability>
@@ -115,77 +110,6 @@ export const StandaloneAvailability: Story = {
       <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
         <AvailabilityTemplate
           labels={{ available: "In stock", outOfStock: "Out of stock" }}
-        />
-      </Availability>
-    </CommerceLayer>
-  ),
-}
-
-export const CustomLabels: Story = {
-  name: "AvailabilityTemplate — custom labels",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
-        <AvailabilityTemplate
-          labels={{
-            available: "✅ In stock",
-            outOfStock: "❌ Sold out",
-            negativeStock: "⚠️ Not available",
-          }}
-        />
-      </Availability>
-    </CommerceLayer>
-  ),
-}
-
-export const WithDeliveryLeadTimeDays: Story = {
-  name: "AvailabilityTemplate — lead time in days",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
-        <AvailabilityTemplate
-          labels={{ available: "Available" }}
-          timeFormat="days"
-        />
-      </Availability>
-    </CommerceLayer>
-  ),
-}
-
-export const WithDeliveryLeadTimeHours: Story = {
-  name: "AvailabilityTemplate — lead time in hours",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
-        <AvailabilityTemplate
-          labels={{ available: "Available" }}
-          timeFormat="hours"
-        />
-      </Availability>
-    </CommerceLayer>
-  ),
-}
-
-export const WithShippingMethodName: Story = {
-  name: "AvailabilityTemplate — with shipping method name",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
-        <AvailabilityTemplate timeFormat="days" showShippingMethodName />
-      </Availability>
-    </CommerceLayer>
-  ),
-}
-
-export const WithShippingMethodPrice: Story = {
-  name: "AvailabilityTemplate — with shipping method price",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
-        <AvailabilityTemplate
-          timeFormat="days"
-          showShippingMethodName
-          showShippingMethodPrice
         />
       </Availability>
     </CommerceLayer>
@@ -208,28 +132,6 @@ export const WithGetQuantityCallback: Story = {
   ),
 }
 
-export const WithChildrenRenderProp: Story = {
-  name: "AvailabilityTemplate — children render prop",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <Availability skuCode="POLOMXXX000000FFFFFFLXXX">
-        <AvailabilityTemplate>
-          {({ quantity, text, min, max }) => (
-            <div style={{ fontFamily: "monospace", fontSize: 14 }}>
-              <strong>{text}</strong>
-              {quantity > 0 && min != null && (
-                <p style={{ marginTop: 4, color: "#666" }}>
-                  Ships in {min.days}–{max?.days ?? min.days} day(s)
-                </p>
-              )}
-            </div>
-          )}
-        </AvailabilityTemplate>
-      </Availability>
-    </CommerceLayer>
-  ),
-}
-
 export const InsideSku: Story = {
   name: "Availability — inside Sku (inherits skuCode)",
   render: () => (
@@ -244,17 +146,6 @@ export const InsideSku: Story = {
           <AvailabilityTemplate />
         </Availability>
       </Sku>
-    </CommerceLayer>
-  ),
-}
-
-export const DeprecatedContainer: Story = {
-  name: "AvailabilityContainer — deprecated (legacy)",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <AvailabilityContainer skuCode="POLOMXXX000000FFFFFFLXXX">
-        <AvailabilityTemplate />
-      </AvailabilityContainer>
     </CommerceLayer>
   ),
 }

--- a/packages/document/src/stories/orders/Order.stories.tsx
+++ b/packages/document/src/stories/orders/Order.stories.tsx
@@ -38,13 +38,13 @@ function OrderDocsPage(): JSX.Element {
         <code>orderId</code> from a parent <code>{"<OrderStorage>"}</code>{" "}
         component.
       </p>
-      <blockquote>
+      <span title="Usage" type="info">
         <p>
-          Must be a child of <code>{"<CommerceLayer>"}</code>. Can optionally
-          be a child of <code>{"<OrderStorage>"}</code> to receive the{" "}
+          Must be a child of <code>{"<CommerceLayer>"}</code>. Can optionally be
+          a child of <code>{"<OrderStorage>"}</code> to receive the{" "}
           <code>orderId</code> automatically.
         </p>
-      </blockquote>
+      </span>
       <ArgTypes />
       <Source
         language="jsx"
@@ -93,61 +93,44 @@ import {
 `}
       />
       <Canvas of={OrderWithCallbackStory} />
-      <hr />
-      <h2>OrderContainer (deprecated)</h2>
-      <blockquote>
-        <p>
-          ⚠️ <strong>Deprecated:</strong>{" "}
-          <code>{"<OrderContainer>"}</code> is deprecated and will be removed
-          in the next major version. Use <code>{"<Order>"}</code> instead — it
-          has the same API and is a drop-in replacement.
-        </p>
-      </blockquote>
-      <p>
-        <strong>Before (deprecated):</strong>
-      </p>
-      <Source
-        language="jsx"
-        dark
-        code={`
-import { CommerceLayer, OrderContainer, OrderNumber, TotalAmount } from '@commercelayer/react-components'
-
-<CommerceLayer accessToken="...">
-  <OrderContainer orderId="KaeheROdbp">
-    <div>Order #<OrderNumber /></div>
-    <div>Total: <TotalAmount /></div>
-  </OrderContainer>
-</CommerceLayer>
-`}
-      />
-      <p>
-        <strong>After (preferred):</strong>
-      </p>
-      <Source
-        language="jsx"
-        dark
-        code={`
-import { CommerceLayer, Order, OrderNumber, TotalAmount } from '@commercelayer/react-components'
-
-<CommerceLayer accessToken="...">
-  <Order orderId="KaeheROdbp">
-    <div>Order #<OrderNumber /></div>
-    <div>Total: <TotalAmount /></div>
-  </Order>
-</CommerceLayer>
-`}
-      />
     </>
   )
 }
 
 const meta = {
-  title: "Orders/Order",
+  title: "Components/Orders/Order",
   component: Order,
   parameters: {
     layout: "centered",
     docs: {
       page: OrderDocsPage,
+    },
+  },
+  argTypes: {
+    orderId: {
+      control: "text",
+      description:
+        "ID of the order to fetch. Omit to create a new draft order on demand.",
+    },
+    metadata: {
+      control: "object",
+      description:
+        "Metadata key-value pairs added when a new order is created.",
+    },
+    attributes: {
+      control: "object",
+      description:
+        "Order attributes applied when the order is created or updated (e.g. `language_code`, `coupon_code`).",
+    },
+    fetchOrder: {
+      control: false,
+      description:
+        "Callback fired every time the order is updated. Receives the updated `Order` SDK object — useful for syncing cart badge counts or analytics.",
+    },
+    children: {
+      control: false,
+      description:
+        "Accepts order display components such as `<OrderNumber>`, `<TotalAmount>`, `<AddToCartButton>`, etc.",
     },
   },
 } satisfies Meta<typeof Order>

--- a/packages/document/src/stories/orders/OrderContainer.stories.tsx
+++ b/packages/document/src/stories/orders/OrderContainer.stories.tsx
@@ -1,0 +1,124 @@
+import {
+  Order,
+  OrderContainer,
+  OrderNumber,
+  TotalAmount,
+} from "@commercelayer/react-components"
+import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import CommerceLayer from "../_internals/CommerceLayer"
+
+function OrderContainerDocsPage(): JSX.Element {
+  return (
+    <>
+      <h1>OrderContainer</h1>
+      <span title="Deprecated" type="warning">
+        <p>
+          Use <code>{"<Order>"}</code> instead — it has the same API and is a drop-in replacement.
+          See <strong>Orders/Order</strong> for the recommended pattern.{" "}
+          <code>{"<OrderContainer>"}</code> will be removed in the next major version.
+        </p>
+      </span>
+      <p>
+        <code>{"<OrderContainer>"}</code> fetches an order by ID and stores it in context for its
+        children. It also fires the optional <code>fetchOrder</code> callback every time the order
+        is updated.
+      </p>
+      <ArgTypes />
+      <hr />
+      <h2>Migration guide</h2>
+      <p>
+        <strong>Before (deprecated):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, OrderContainer, OrderNumber, TotalAmount } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="...">
+  <OrderContainer orderId="KaeheROdbp">
+    <div>Order #<OrderNumber /></div>
+    <div>Total: <TotalAmount /></div>
+  </OrderContainer>
+</CommerceLayer>
+`}
+      />
+      <p>
+        <strong>After (recommended):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, Order, OrderNumber, TotalAmount } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="...">
+  <Order orderId="KaeheROdbp">
+    <div>Order #<OrderNumber /></div>
+    <div>Total: <TotalAmount /></div>
+  </Order>
+</CommerceLayer>
+`}
+      />
+      <hr />
+      <h2>Example</h2>
+      <Canvas of={OrderContainerStory} />
+    </>
+  )
+}
+
+const meta = {
+  title: "Components/Orders/OrderContainer",
+  component: OrderContainer,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: OrderContainerDocsPage,
+    },
+  },
+  argTypes: {
+    orderId: {
+      control: "text",
+      description: "ID of the order to fetch.",
+    },
+    metadata: {
+      control: "object",
+      description: "Metadata key-value pairs added when a new order is created.",
+    },
+    attributes: {
+      control: "object",
+      description:
+        "Order attributes applied when the order is created or updated (e.g. `language_code`, `coupon_code`).",
+    },
+    fetchOrder: {
+      control: false,
+      description:
+        "Callback fired every time the order is updated. Receives the updated `Order` SDK object.",
+    },
+    children: {
+      control: false,
+      description:
+        "Accepts order display components such as `<OrderNumber>`, `<TotalAmount>`, `<AddToCartButton>`, etc.",
+    },
+  },
+} satisfies Meta<typeof OrderContainer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const OrderContainerStory: Story = {
+  name: "OrderContainer — display order details",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <OrderContainer orderId="KaeheROdbp">
+        <div>
+          Order #<OrderNumber />
+        </div>
+        <div>
+          Total: <TotalAmount />
+        </div>
+      </OrderContainer>
+    </CommerceLayer>
+  ),
+}

--- a/packages/document/src/stories/prices/PricesContainer.stories.tsx
+++ b/packages/document/src/stories/prices/PricesContainer.stories.tsx
@@ -1,0 +1,150 @@
+import { Price, PricesContainer } from "@commercelayer/react-components"
+import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import CommerceLayer from "../_internals/CommerceLayer"
+
+function PricesContainerDocsPage(): JSX.Element {
+  return (
+    <>
+      <h1>PricesContainer</h1>
+      <span title="Deprecated" type="warning">
+        <p>
+          <code>{"<PricesContainer>"}</code> is deprecated and will be removed in a future major
+          release. Use <code>{'<Price skuCode="…" />'}</code> as a standalone component instead —
+          it handles batching automatically. See <strong>Prices/Price</strong> for the recommended
+          pattern.
+        </p>
+      </span>
+      <p>
+        <code>{"<PricesContainer>"}</code> fetches prices for one or more SKU codes and stores them
+        in a React context for its <code>{"<Price>"}</code> children. Multiple{" "}
+        <code>{"<Price>"}</code> children each register their own <code>skuCode</code> — the
+        container batches all registrations into a single API request using a 50 ms debounce.
+      </p>
+      <ArgTypes />
+      <hr />
+      <h2>Migration guide</h2>
+      <p>
+        <strong>Before (deprecated):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, PricesContainer, Price } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="...">
+  <PricesContainer skuCode="MY-SKU-CODE">
+    <Price />
+  </PricesContainer>
+</CommerceLayer>
+`}
+      />
+      <p>
+        <strong>After (recommended):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, Price } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="...">
+  <Price skuCode="MY-SKU-CODE" />
+</CommerceLayer>
+`}
+      />
+      <hr />
+      <h2>Examples</h2>
+      <Canvas of={SingleSkuStory} />
+      <Canvas of={BatchedPricesStory} />
+      <Canvas of={WithFiltersStory} />
+    </>
+  )
+}
+
+const meta = {
+  title: "Components/Prices/PricesContainer",
+  component: PricesContainer,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: PricesContainerDocsPage,
+    },
+  },
+  argTypes: {
+    skuCode: {
+      control: "text",
+      description:
+        "SKU code to fetch the prices for. If not provided, the `sku_code` will be retrieved from the nested `<Price>` components.",
+    },
+    filters: {
+      control: "object",
+      description: "SDK query filter to fetch the prices when multiple prices are requested.",
+    },
+    perPage: {
+      control: "number",
+      description: "Number of prices per page to fetch.",
+    },
+    loader: {
+      control: "text",
+      description: "Content displayed while prices are loading.",
+    },
+    children: {
+      control: false,
+      description: "Accepts `<Price>` components as children.",
+    },
+  },
+} satisfies Meta<typeof PricesContainer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const SingleSkuStory: Story = {
+  name: "PricesContainer — single SKU",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <PricesContainer skuCode="POST6191FFFFFF000000XXXX">
+        <Price
+          style={{ fontWeight: "bold", fontSize: "1.25rem" }}
+          compareClassName="line-through ml-2"
+        />
+      </PricesContainer>
+    </CommerceLayer>
+  ),
+}
+
+export const BatchedPricesStory: Story = {
+  name: "PricesContainer — batched (single API request)",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <PricesContainer>
+        <div style={{ display: "grid", gap: 12 }}>
+          <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+            <span style={{ width: 220, fontSize: "0.85rem", color: "#666" }}>
+              POST6191FFFFFF000000XXXX
+            </span>
+            <Price skuCode="POST6191FFFFFF000000XXXX" style={{ fontWeight: "bold" }} />
+          </div>
+          <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+            <span style={{ width: 220, fontSize: "0.85rem", color: "#666" }}>
+              POLOMXXX000000FFFFFFLXXX
+            </span>
+            <Price skuCode="POLOMXXX000000FFFFFFLXXX" style={{ fontWeight: "bold" }} />
+          </div>
+        </div>
+      </PricesContainer>
+    </CommerceLayer>
+  ),
+}
+
+export const WithFiltersStory: Story = {
+  name: "PricesContainer — with filters",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <PricesContainer skuCode="POST6191FFFFFF000000XXXX" filters={{ currency_code_eq: "EUR" }}>
+        <Price style={{ fontWeight: "bold" }} />
+      </PricesContainer>
+    </CommerceLayer>
+  ),
+}

--- a/packages/document/src/stories/prices/prices.stories.tsx
+++ b/packages/document/src/stories/prices/prices.stories.tsx
@@ -1,4 +1,4 @@
-import { Price, PricesContainer } from "@commercelayer/react-components"
+import { Price } from "@commercelayer/react-components"
 import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import CommerceLayer from "../_internals/CommerceLayer"
@@ -32,13 +32,13 @@ function PricesDocsPage(): JSX.Element {
         collects all sibling registrations into{" "}
         <strong>one SWR-deduplicated API request</strong>.
       </p>
-      <blockquote>
+      <span title="Note" type="info">
         <p>
           No provider or wrapper needed. Drop{" "}
           <code>{'<Price skuCode="…" />'}</code> anywhere inside{" "}
           <code>{"<CommerceLayer>"}</code> and batching happens automatically.
         </p>
-      </blockquote>
+      </span>
       <ArgTypes />
       <Source
         language="jsx"
@@ -86,73 +86,12 @@ import { CommerceLayer, Price } from '@commercelayer/react-components'
 `}
       />
       <Canvas of={RenderPropStory} />
-      <hr />
-      <h2>PricesContainer (deprecated)</h2>
-      <blockquote>
-        <p>
-          ⚠️ <strong>Deprecated:</strong>{" "}
-          <code>{"<PricesContainer>"}</code> is deprecated and will be removed
-          in a future major release. Use <code>{'<Price skuCode="…" />'}</code>{" "}
-          as a standalone component instead — it handles batching automatically.
-        </p>
-      </blockquote>
-      <p>
-        <code>{"<PricesContainer>"}</code> fetches prices for one or more SKU
-        codes and stores them in a React context for its{" "}
-        <code>{"<Price>"}</code> children. Multiple <code>{"<Price>"}</code>{" "}
-        children each register their own <code>skuCode</code> — the container
-        batches all registrations into a single API request using a 50 ms
-        debounce.
-      </p>
-      <Source
-        language="jsx"
-        dark
-        code={`
-// Deprecated — prefer standalone <Price> instead
-import { CommerceLayer, PricesContainer, Price } from '@commercelayer/react-components'
-
-<CommerceLayer accessToken="...">
-  <PricesContainer skuCode="MY-SKU-CODE">
-    <Price />
-  </PricesContainer>
-</CommerceLayer>
-`}
-      />
-      <Canvas of={SingleSkuStory} />
-      <hr />
-      <h2>PricesContainer — batched (deprecated)</h2>
-      <p>
-        Mount multiple <code>{"<Price>"}</code> components inside{" "}
-        <code>{"<PricesContainer>"}</code> — each registers its{" "}
-        <code>skuCode</code> and the container debounces all registrations into{" "}
-        <strong>one API call</strong>.
-      </p>
-      <blockquote>
-        <p>
-          This pattern is still supported but deprecated. The same batching now
-          happens automatically when you use standalone{" "}
-          <code>{"<Price>"}</code> components without any container.
-        </p>
-      </blockquote>
-      <Source
-        language="jsx"
-        dark
-        code={`
-// Deprecated — prefer standalone <Price> components instead
-<PricesContainer>
-  <Price skuCode="SKU-A" />
-  <Price skuCode="SKU-B" />
-  <Price skuCode="SKU-C" />
-</PricesContainer>
-`}
-      />
-      <Canvas of={BatchedPricesStory} />
     </>
   )
 }
 
 const meta = {
-  title: "Prices/Price",
+  title: "Components/Prices/Price",
   component: Price,
   parameters: {
     layout: "centered",
@@ -160,101 +99,67 @@ const meta = {
       page: PricesDocsPage,
     },
   },
+  argTypes: {
+    skuCode: {
+      control: "text",
+      description:
+        "The SKU code whose price to fetch. When used standalone (no `PricesContainer` parent), this triggers an automatic batched API request.",
+    },
+    showCompare: {
+      control: "boolean",
+      description:
+        "When `false`, the `compare_at` (strike-through) price is not displayed.",
+    },
+    compareClassName: {
+      control: "text",
+      description: "CSS class name applied to the compare-at price element.",
+    },
+    loader: {
+      control: "text",
+      description:
+        "Content displayed while the price is loading in standalone mode.",
+    },
+    children: {
+      control: false,
+      description:
+        "Render prop receiving `{ prices, loading, loader }` for a fully custom price UI.",
+    },
+  },
 } satisfies Meta<typeof Price>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const SingleSkuStory: Story = {
-  name: "PricesContainer — single SKU",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <PricesContainer skuCode="POST6191FFFFFF000000XXXX">
-        <Price
-          style={{ fontWeight: "bold", fontSize: "1.25rem" }}
-          compareClassName="line-through ml-2"
-        />
-      </PricesContainer>
-    </CommerceLayer>
-  ),
-}
-
-export const BatchedPricesStory: Story = {
-  name: "PricesContainer — batched (single API request)",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <PricesContainer>
-        <div style={{ display: "grid", gap: 12 }}>
-          <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
-            <span style={{ width: 220, fontSize: "0.85rem", color: "#666" }}>
-              POST6191FFFFFF000000XXXX
-            </span>
-            <Price
-              skuCode="POST6191FFFFFF000000XXXX"
-              style={{ fontWeight: "bold" }}
-            />
-          </div>
-          <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
-            <span style={{ width: 220, fontSize: "0.85rem", color: "#666" }}>
-              POLOMXXX000000FFFFFFLXXX
-            </span>
-            <Price
-              skuCode="POLOMXXX000000FFFFFFLXXX"
-              style={{ fontWeight: "bold" }}
-            />
-          </div>
-        </div>
-      </PricesContainer>
-    </CommerceLayer>
-  ),
-}
-
 export const RenderPropStory: Story = {
   name: "Price — children render prop",
   render: () => (
     <CommerceLayer accessToken="my-access-token">
-      <PricesContainer skuCode="POST6191FFFFFF000000XXXX">
-        <Price>
-          {({ prices, loading }) => {
-            if (loading) return <span style={{ color: "#999" }}>Loading…</span>
-            if (prices.length === 0)
-              return <span style={{ color: "red" }}>No price available</span>
-            const [p] = prices
-            return (
-              <div>
-                <strong style={{ fontSize: "1.25rem" }}>
-                  {p.formatted_amount}
-                </strong>
-                {p.formatted_compare_at_amount != null && (
-                  <s style={{ marginLeft: 8, color: "#999" }}>
-                    {p.formatted_compare_at_amount}
-                  </s>
-                )}
-              </div>
-            )
-          }}
-        </Price>
-      </PricesContainer>
-    </CommerceLayer>
-  ),
-}
-
-export const WithFiltersStory: Story = {
-  name: "PricesContainer — with filters",
-  render: () => (
-    <CommerceLayer accessToken="my-access-token">
-      <PricesContainer
-        skuCode="POST6191FFFFFF000000XXXX"
-        filters={{ currency_code_eq: "EUR" }}
-      >
-        <Price style={{ fontWeight: "bold" }} />
-      </PricesContainer>
+      <Price skuCode="POST6191FFFFFF000000XXXX">
+        {({ prices, loading }) => {
+          if (loading) return <span style={{ color: "#999" }}>Loading…</span>
+          if (prices.length === 0)
+            return <span style={{ color: "red" }}>No price available</span>
+          const [p] = prices
+          return (
+            <div>
+              <strong style={{ fontSize: "1.25rem" }}>
+                {p.formatted_amount}
+              </strong>
+              {p.formatted_compare_at_amount != null && (
+                <s style={{ marginLeft: 8, color: "#999" }}>
+                  {p.formatted_compare_at_amount}
+                </s>
+              )}
+            </div>
+          )
+        }}
+      </Price>
     </CommerceLayer>
   ),
 }
 
 export const StandalonePrice: Story = {
-  name: "Price — standalone (no PricesContainer)",
+  name: "Price — standalone",
   render: () => (
     <CommerceLayer accessToken="my-access-token">
       <div style={{ display: "grid", gap: 12 }}>

--- a/packages/document/src/stories/skus/Sku.stories.tsx
+++ b/packages/document/src/stories/skus/Sku.stories.tsx
@@ -1,0 +1,107 @@
+import { Sku, SkuField } from "@commercelayer/react-components"
+import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import CommerceLayer from "../_internals/CommerceLayer"
+
+function SkusDocsPage(): JSX.Element {
+  return (
+    <>
+      <h1>SKUs</h1>
+      <p>
+        The SKU components let you fetch and display product data from the Commerce Layer API. All
+        SKU components must be nested inside the <code>{"<CommerceLayer>"}</code> context that
+        handles API authentication.
+      </p>
+      <p>
+        Refer to the{" "}
+        <a href="https://docs.commercelayer.io/core/v/api-reference/skus/object">
+          SKUs API reference
+        </a>{" "}
+        for the full list of available attributes.
+      </p>
+      <hr />
+      <h2>Sku (standalone — recommended)</h2>
+      <p>
+        <code>{"<Sku>"}</code> is a standalone component that fetches and displays SKU data without
+        requiring a <code>{"<SkusContainer>"}</code> parent. Multiple sibling <code>{"<Sku>"}</code>{" "}
+        components are automatically batched into a single API request via a module-level debounce
+        store, so rendering many SKUs on one page is efficient.
+      </p>
+      <span title="Usage" type="info">
+        <p>
+          Must be a child of <code>{"<CommerceLayer>"}</code>. Accepts <code>{"<SkuField>"}</code>{" "}
+          and <code>{"<AvailabilityContainer>"}</code> as children.
+        </p>
+      </span>
+      <ArgTypes />
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, Sku, SkuField } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="..." endpoint="https://yourdomain.commercelayer.io">
+  <Sku skuCode="TSHIRTWS000000FFFFFFLXXX">
+    <SkuField attribute="name" tagElement="h2" />
+    <SkuField attribute="description" tagElement="p" />
+  </Sku>
+  <Sku skuCode="TSHIRTWKFFFFFF000000MXXX">
+    <SkuField attribute="name" tagElement="h2" />
+    <SkuField attribute="description" tagElement="p" />
+  </Sku>
+</CommerceLayer>
+`}
+      />
+      <Canvas of={StandaloneSkuStory} />
+    </>
+  )
+}
+
+const meta = {
+  title: "Components/Skus/Sku",
+  component: Sku,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: SkusDocsPage,
+    },
+  },
+  argTypes: {
+    skuCode: {
+      control: "text",
+      description:
+        "The SKU code to fetch. Multiple sibling `<Sku>` components with different codes are batched into a single API request.",
+    },
+    loader: {
+      control: "text",
+      description: "Content displayed while the SKU data is loading.",
+    },
+    children: {
+      control: false,
+      description: "Accepts `<SkuField>` and `<AvailabilityContainer>` as children.",
+    },
+  },
+} satisfies Meta<typeof Sku>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const StandaloneSkuStory: Story = {
+  name: "Sku — standalone (no container)",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <Sku skuCode="TSHIRTWS000000FFFFFFLXXX">
+        <div style={{ marginBottom: 12 }}>
+          <SkuField attribute="name" tagElement="h3" />
+          <SkuField attribute="code" tagElement="p" />
+        </div>
+      </Sku>
+      <Sku skuCode="TSHIRTWKFFFFFF000000MXXX">
+        <div style={{ marginBottom: 12 }}>
+          <SkuField attribute="name" tagElement="h3" />
+          <SkuField attribute="code" tagElement="p" />
+        </div>
+      </Sku>
+    </CommerceLayer>
+  ),
+}

--- a/packages/document/src/stories/skus/SkuList.stories.tsx
+++ b/packages/document/src/stories/skus/SkuList.stories.tsx
@@ -3,17 +3,18 @@ import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import CommerceLayer from "../_internals/CommerceLayer"
 
-function SkusDocsPage(): JSX.Element {
+function SkuListDocsPage(): JSX.Element {
   return (
     <>
-      <h1>Skus</h1>
+      <h1>SkuList</h1>
       <p>
-        <code>{"<Skus>"}</code> iterates over every SKU fetched by its parent container and renders
-        its children once per record — no manual looping required.
+        <code>{"<SkuList>"}</code> fetches and renders SKUs belonging to a Commerce Layer SKU list.
+        It can be used as a standalone component — pass the SKU list <code>id</code> directly and
+        nest <code>{"<Skus>"}</code> inside to iterate over the list items.
       </p>
       <span title="Usage" type="info">
         <p>
-          Must be a direct child of <code>{"<SkuList>"}</code>. Accepts{" "}
+          Must be a child of <code>{"<CommerceLayer>"}</code>. Accepts <code>{"<Skus>"}</code> and{" "}
           <code>{"<SkuField>"}</code> as children.
         </p>
       </span>
@@ -29,41 +30,53 @@ import { CommerceLayer, SkuList, Skus, SkuField } from '@commercelayer/react-com
 <CommerceLayer accessToken="..." endpoint="https://yourdomain.commercelayer.io">
   <SkuList id="yZjQIDxrly">
     <Skus>
-      {/* rendered once per SKU */}
-      <SkuField attribute="name" tagElement="h3" />
+      <SkuField attribute="name" tagElement="h2" />
       <SkuField attribute="code" tagElement="p" />
     </Skus>
   </SkuList>
 </CommerceLayer>
 `}
       />
-      <Canvas of={Default} />
+      <Canvas of={StandaloneSkuList} />
     </>
   )
 }
 
 const meta = {
-  title: "Components/Skus/Skus",
-  component: Skus,
+  title: "Components/Skus/SkuList",
+  component: SkuList,
   parameters: {
     layout: "centered",
     docs: {
-      page: SkusDocsPage,
+      page: SkuListDocsPage,
     },
   },
   argTypes: {
+    id: {
+      control: "text",
+      description: "The ID of the SKU list to fetch.",
+    },
+    params: {
+      control: "object",
+      description:
+        "Optional query parameters forwarded to the SKU list retrieval call. `include: [\"skus\"]` is always enforced. Use `fields.skus` to request additional SKU attributes.",
+    },
+    loader: {
+      control: "text",
+      description: "Content displayed while the SKU list data is loading.",
+    },
     children: {
       control: false,
-      description: "Rendered once per SKU. Accepts `<SkuField>` as children.",
+      description: "Accepts `<Skus>` and `<SkuField>` as children.",
     },
   },
-} satisfies Meta<typeof Skus>
+} satisfies Meta<typeof SkuList>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-  name: "Skus — inside SkuList",
+export const StandaloneSkuList: Story = {
+  name: "SkuList — standalone (no container)",
   render: () => (
     <CommerceLayer accessToken="my-access-token">
       <SkuList id="yZjQIDxrly" params={{ fields: { skus: ["code", "name"] } }}>

--- a/packages/document/src/stories/skus/SkuListsContainer.stories.tsx
+++ b/packages/document/src/stories/skus/SkuListsContainer.stories.tsx
@@ -1,0 +1,120 @@
+import { SkuField, SkuList, SkuListsContainer, Skus } from "@commercelayer/react-components"
+import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import CommerceLayer from "../_internals/CommerceLayer"
+
+function SkuListsContainerDocsPage(): JSX.Element {
+  return (
+    <>
+      <h1>SkuListsContainer</h1>
+      <span title="Deprecated" type="warning">
+        <p>
+          Use the standalone <code>{'<SkuList id="...">'}</code> component instead — it fetches its
+          own data without requiring a container parent. See <strong>Skus/SkuList</strong> for the
+          recommended pattern. <code>{"<SkuListsContainer>"}</code> will be removed in the next
+          major version.
+        </p>
+      </span>
+      <p>
+        <code>{"<SkuListsContainer>"}</code> fetches one or more SKU lists by ID and makes their SKU
+        data available to child <code>{"<SkuList>"}</code> components. Each{" "}
+        <code>{"<SkuList>"}</code> registers its own ID with this container on mount.
+      </p>
+      <ArgTypes />
+      <hr />
+      <h2>Migration guide</h2>
+      <p>
+        <strong>Before (deprecated):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import {
+  CommerceLayer,
+  SkuListsContainer,
+  SkuList,
+  Skus,
+  SkuField,
+} from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="..." endpoint="https://yourdomain.commercelayer.io">
+  <SkuListsContainer>
+    <SkuList id="yZjQIDxrly">
+      <Skus>
+        <SkuField attribute="name" tagElement="h2" />
+        <SkuField attribute="code" tagElement="p" />
+      </Skus>
+    </SkuList>
+  </SkuListsContainer>
+</CommerceLayer>
+`}
+      />
+      <p>
+        <strong>After (recommended):</strong>
+      </p>
+      <Source
+        language="jsx"
+        dark
+        code={`
+import { CommerceLayer, SkuList, Skus, SkuField } from '@commercelayer/react-components'
+
+<CommerceLayer accessToken="..." endpoint="https://yourdomain.commercelayer.io">
+  <SkuList id="yZjQIDxrly">
+    <Skus>
+      <SkuField attribute="name" tagElement="h2" />
+      <SkuField attribute="code" tagElement="p" />
+    </Skus>
+  </SkuList>
+</CommerceLayer>
+`}
+      />
+      <hr />
+      <h2>Example</h2>
+      <Canvas of={SkuListsContainerStory} />
+    </>
+  )
+}
+
+const meta = {
+  title: "Components/Skus/SkuListsContainer",
+  component: SkuListsContainer,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: SkuListsContainerDocsPage,
+    },
+  },
+  argTypes: {
+    params: {
+      control: "object",
+      description:
+        "Optional query parameters forwarded to each SKU list retrieval call. `include: [\"skus\"]` is always enforced. Use `fields.skus` to request additional SKU attributes.",
+    },
+    children: {
+      control: false,
+      description: "Accepts `<SkuList>` as children.",
+    },
+  },
+} satisfies Meta<typeof SkuListsContainer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const SkuListsContainerStory: Story = {
+  name: "SkuListsContainer — list items",
+  render: () => (
+    <CommerceLayer accessToken="my-access-token">
+      <SkuListsContainer params={{ fields: { skus: ["code", "name"] } }}>
+        <SkuList id="yZjQIDxrly">
+          <Skus>
+            <div style={{ marginBottom: 12 }}>
+              <SkuField attribute="name" tagElement="h3" />
+              <SkuField attribute="code" tagElement="p" />
+            </div>
+          </Skus>
+        </SkuList>
+      </SkuListsContainer>
+    </CommerceLayer>
+  ),
+}

--- a/packages/document/src/stories/skus/SkusContainer.stories.tsx
+++ b/packages/document/src/stories/skus/SkusContainer.stories.tsx
@@ -1,8 +1,4 @@
-import {
-  SkuField,
-  Skus,
-  SkusContainer,
-} from "@commercelayer/react-components"
+import { SkuField, Skus, SkusContainer } from "@commercelayer/react-components"
 import { ArgTypes, Canvas, Source } from "@storybook/addon-docs/blocks"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import CommerceLayer from "../_internals/CommerceLayer"
@@ -11,20 +7,18 @@ function SkusContainerDocsPage(): JSX.Element {
   return (
     <>
       <h1>SkusContainer</h1>
-      <blockquote>
+      <span title="Deprecated" type="warning">
         <p>
-          ⚠️ <strong>Deprecated.</strong> Use the standalone{" "}
-          <code>{'<Sku skuCode="...">'}</code> component instead — it batches
-          requests automatically and requires no container. See{" "}
-          <strong>Skus/Sku</strong> for the recommended pattern.
-          <code>{"<SkusContainer>"}</code> will be removed in the next major
+          Use the standalone <code>{'<Sku skuCode="...">'}</code> component instead — it batches
+          requests automatically and requires no container. See <strong>Skus/Sku</strong> for the
+          recommended pattern. <code>{"<SkusContainer>"}</code> will be removed in the next major
           version.
         </p>
-      </blockquote>
+      </span>
       <p>
-        <code>{"<SkusContainer>"}</code> fetches an array of SKUs by code and
-        stores them in a React context for its <code>{"<Skus>"}</code> children.
-        Internally it debounces registrations into a single API call.
+        <code>{"<SkusContainer>"}</code> fetches an array of SKUs by code and stores them in a React
+        context for its <code>{"<Skus>"}</code> children. Internally it debounces registrations into
+        a single API call.
       </p>
       <ArgTypes />
       <hr />
@@ -70,32 +64,6 @@ import { CommerceLayer, Sku, SkuField } from '@commercelayer/react-components'
 `}
       />
       <hr />
-      <h2>Skus</h2>
-      <p>
-        <code>{"<Skus>"}</code> is a child of <code>{"<SkusContainer>"}</code>.
-        It iterates over every SKU fetched by the container and renders its
-        children once per record — no manual looping required.
-      </p>
-      <blockquote>
-        <p>
-          Must be a direct child of <code>{"<SkusContainer>"}</code>. Accepts{" "}
-          <code>{"<SkuField>"}</code> and{" "}
-          <code>{"<AvailabilityContainer>"}</code> as children.
-        </p>
-      </blockquote>
-      <Source
-        language="jsx"
-        dark
-        code={`
-<SkusContainer skus={["TSHIRTWS000000FFFFFFLXXX", "TSHIRTWKFFFFFF000000MXXX"]}>
-  <Skus>
-    {/* rendered once per SKU */}
-    <SkuField attribute="name" tagElement="h3" />
-  </Skus>
-</SkusContainer>
-`}
-      />
-      <hr />
       <h2>Examples</h2>
       <Canvas of={Default} />
       <Canvas of={WithQueryParams} />
@@ -104,12 +72,27 @@ import { CommerceLayer, Sku, SkuField } from '@commercelayer/react-components'
 }
 
 const meta = {
-  title: "Skus/SkusContainer",
+  title: "Components/Skus/SkusContainer",
   component: SkusContainer,
   parameters: {
     layout: "centered",
     docs: {
       page: SkusContainerDocsPage,
+    },
+  },
+  argTypes: {
+    skus: {
+      control: "object",
+      description: "Array of SKU codes to fetch. All codes are batched into a single API request.",
+    },
+    queryParams: {
+      control: "object",
+      description:
+        "Optional query parameters forwarded to the SKUs API request (pagination, sorting, field selection, filters).",
+    },
+    children: {
+      control: false,
+      description: "Accepts `<Skus>` as a child to iterate over fetched SKUs.",
     },
   },
 } satisfies Meta<typeof SkusContainer>
@@ -123,10 +106,7 @@ export const Default: Story = {
     skus: ["POLOMXXX000000FFFFFFLXXX", "CROPTOPWFFFFFF000000XSXX"],
   },
   render: (args) => (
-    <CommerceLayer
-      accessToken="my-access-token"
-      endpoint="https://demo-store.commercelayer.io"
-    >
+    <CommerceLayer accessToken="my-access-token" endpoint="https://demo-store.commercelayer.io">
       <SkusContainer {...args}>
         <Skus>
           <div style={{ marginBottom: 12 }}>
@@ -151,10 +131,7 @@ export const WithQueryParams: Story = {
     },
   },
   render: (args) => (
-    <CommerceLayer
-      accessToken="my-access-token"
-      endpoint="https://demo-store.commercelayer.io"
-    >
+    <CommerceLayer accessToken="my-access-token" endpoint="https://demo-store.commercelayer.io">
       <SkusContainer {...args}>
         <Skus>
           <div style={{ marginBottom: 12 }}>


### PR DESCRIPTION
## Summary

Each deprecated container component now has its own dedicated Storybook story file, keeping the parent stories clean and focused on the recommended API.

## Changes

### SKUs
- `Skus.stories.tsx` → split into `Sku.stories.tsx` (standalone `<Sku>`) and `Skus.stories.tsx` (`<Skus>` iterator)
- New `SkuList.stories.tsx` — standalone `<SkuList>`
- New `SkuListsContainer.stories.tsx` — deprecated, with migration guide

### Orders
- New `OrderContainer.stories.tsx` — deprecated, with migration guide pointing to `<Order>`
- `Order.stories.tsx` — removed `OrderContainer` section

### Prices
- New `PricesContainer.stories.tsx` — deprecated, with migration guide pointing to standalone `<Price>`
- `prices.stories.tsx` — title fixed to `Components/Prices/Price`, deprecated stories removed, `RenderPropStory` updated to use standalone `<Price>`

### Availability
- New `AvailabilityContainer.stories.tsx` — deprecated, with migration guide
- New `AvailabilityTemplate.stories.tsx` — own story with all template-specific stories (custom labels, lead times, shipping, render prop)
- `availability.stories.tsx` — title fixed to `Components/Availability/Availability`, extracted sections removed

## Notes
- All deprecated stories follow the same pattern as `SkusContainer.stories.tsx` (deprecation warning + migration guide)
- All `meta.title` values now sit under the correct Storybook submenu (e.g. `Components/Prices/...`, `Components/Availability/...`)
- Pre-commit hook failure is due to pre-existing lint errors in `hooks` and `react-components` packages (unrelated to this PR)