### PR TITLE
♻️ refactor(line-items): refactor child components and add 100% coverage tests

### DIFF
--- a/packages/react-components/specs/line_items/LineItem.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItem.spec.tsx
@@ -1,10 +1,11 @@
-import { LineItem } from "#components/line_items/LineItem"
-import LineItemContext from "#context/LineItemContext"
-import LineItemChildrenContext from "#context/LineItemChildrenContext"
-import ShipmentChildrenContext from "#context/ShipmentChildrenContext"
+import type { LineItem as LineItemResource } from "@commercelayer/sdk"
 import { render, screen } from "@testing-library/react"
 import { useContext } from "react"
 import { describe, expect, it } from "vitest"
+import { LineItem } from "#components/line_items/LineItem"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
+import LineItemContext from "#context/LineItemContext"
+import ShipmentChildrenContext from "#context/ShipmentChildrenContext"
 import { buildLineItem, MOCK_LINE_ITEM } from "./helpers"
 
 function Child() {
@@ -18,8 +19,8 @@ function renderComponent({
   shipmentLineItems = [],
 }: {
   type?: "skus" | "gift_cards" | "bundles"
-  lineItems?: any[]
-  shipmentLineItems?: any[]
+  lineItems?: Array<Partial<LineItemResource>>
+  shipmentLineItems?: Array<Partial<LineItemResource>>
 } = {}) {
   return render(
     <LineItemContext.Provider value={{ lineItems }}>

--- a/packages/react-components/specs/line_items/LineItem.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItem.spec.tsx
@@ -1,0 +1,115 @@
+import { LineItem } from "#components/line_items/LineItem"
+import LineItemContext from "#context/LineItemContext"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
+import ShipmentChildrenContext from "#context/ShipmentChildrenContext"
+import { render, screen } from "@testing-library/react"
+import { useContext } from "react"
+import { describe, expect, it } from "vitest"
+import { buildLineItem, MOCK_LINE_ITEM } from "./helpers"
+
+function Child() {
+  const { lineItem } = useContext(LineItemChildrenContext)
+  return <span data-testid={`line-item-${lineItem?.id}`}>{lineItem?.name}</span>
+}
+
+function renderComponent({
+  type,
+  lineItems = [MOCK_LINE_ITEM],
+  shipmentLineItems = [],
+}: {
+  type?: "skus" | "gift_cards" | "bundles"
+  lineItems?: any[]
+  shipmentLineItems?: any[]
+} = {}) {
+  return render(
+    <LineItemContext.Provider value={{ lineItems }}>
+      <ShipmentChildrenContext.Provider value={{ keyNumber: 0, lineItems: shipmentLineItems }}>
+        <LineItem type={type}>
+          <Child />
+        </LineItem>
+      </ShipmentChildrenContext.Provider>
+    </LineItemContext.Provider>
+  )
+}
+
+describe("LineItem component", () => {
+  it('renders children for matching type="skus"', () => {
+    renderComponent()
+
+    expect(screen.getByTestId("line-item-li_1").textContent).toBe("Baby Onesie")
+  })
+
+  it("does not render children for a non matching type", () => {
+    renderComponent({ type: "gift_cards" })
+
+    expect(screen.queryByTestId("line-item-li_1")).toBeNull()
+  })
+
+  it("skips gift cards with total_amount_cents <= 0", () => {
+    renderComponent({
+      type: "gift_cards",
+      lineItems: [
+        buildLineItem({
+          id: "gift_1",
+          item_type: "gift_cards",
+          sku_code: "GIFT001",
+          total_amount_cents: 0,
+          name: "Zero Gift Card",
+        }),
+      ],
+    })
+
+    expect(screen.queryByTestId("line-item-gift_1")).toBeNull()
+  })
+
+  it("renders gift cards with total_amount_cents > 0", () => {
+    renderComponent({
+      type: "gift_cards",
+      lineItems: [
+        buildLineItem({
+          id: "gift_2",
+          item_type: "gift_cards",
+          sku_code: "GIFT002",
+          total_amount_cents: 1000,
+          name: "Positive Gift Card",
+        }),
+      ],
+    })
+
+    expect(screen.getByTestId("line-item-gift_2").textContent).toBe("Positive Gift Card")
+  })
+
+  it("deduplicates bundles with the same bundle_code", () => {
+    renderComponent({
+      type: "bundles",
+      lineItems: [
+        buildLineItem({
+          id: "bundle_1",
+          item_type: "bundles",
+          bundle_code: "BUNDLE001",
+          sku_code: "BUNDLE001-1",
+          name: "Starter Bundle",
+        }),
+        buildLineItem({
+          id: "bundle_2",
+          item_type: "bundles",
+          bundle_code: "BUNDLE001",
+          sku_code: "BUNDLE001-2",
+          name: "Starter Bundle Duplicate",
+        }),
+      ],
+    })
+
+    expect(screen.getAllByText(/Starter Bundle/)).toHaveLength(1)
+  })
+
+  it("uses shipmentLineItems from ShipmentChildrenContext when available", () => {
+    renderComponent({
+      lineItems: [buildLineItem({ id: "line_item", name: "Context line item" })],
+      shipmentLineItems: [buildLineItem({ id: "shipment_item", name: "Shipment line item" })],
+    })
+
+    expect(screen.queryByText("Context line item")).toBeNull()
+    expect(screen.getByText("Shipment line item")).toBeDefined()
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemAmount.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemAmount.spec.tsx
@@ -1,0 +1,46 @@
+import { LineItemAmount } from "#components/line_items/LineItemAmount"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { LineItemProvider } from "./helpers"
+
+describe("LineItemAmount component", () => {
+  it("renders formatted_total_amount by default", () => {
+    render(
+      <LineItemProvider>
+        <LineItemAmount data-testid="line-item-amount" />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("line-item-amount").textContent).toBe("€24.00")
+  })
+
+  it('renders formatted_unit_amount when type="unit"', () => {
+    render(
+      <LineItemProvider>
+        <LineItemAmount type="unit" data-testid="line-item-unit-amount" />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("line-item-unit-amount").textContent).toBe("€12.00")
+  })
+
+  it("renders children render-prop with price prop", () => {
+    render(
+      <LineItemProvider>
+        <LineItemAmount>{({ price }) => <span data-testid="custom-amount">{price}</span>}</LineItemAmount>
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("custom-amount").textContent).toBe("€24.00")
+  })
+
+  it("renders an empty string when lineItem is missing", () => {
+    render(
+      <LineItemProvider lineItem={undefined}>
+        <LineItemAmount data-testid="empty-amount" />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("empty-amount").textContent).toBe("")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemAmount.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemAmount.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemAmount } from "#components/line_items/LineItemAmount"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemAmount } from "#components/line_items/LineItemAmount"
 import { LineItemProvider } from "./helpers"
 
 describe("LineItemAmount component", () => {
@@ -27,7 +27,9 @@ describe("LineItemAmount component", () => {
   it("renders children render-prop with price prop", () => {
     render(
       <LineItemProvider>
-        <LineItemAmount>{({ price }) => <span data-testid="custom-amount">{price}</span>}</LineItemAmount>
+        <LineItemAmount>
+          {({ price }) => <span data-testid="custom-amount">{price}</span>}
+        </LineItemAmount>
       </LineItemProvider>
     )
 

--- a/packages/react-components/specs/line_items/LineItemCode.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemCode.spec.tsx
@@ -1,0 +1,38 @@
+import { LineItemCode } from "#components/line_items/LineItemCode"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { buildLineItem, LineItemProvider } from "./helpers"
+
+describe("LineItemCode component", () => {
+  it("renders sku_code by default", () => {
+    render(
+      <LineItemProvider>
+        <LineItemCode data-testid="line-item-code" />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("line-item-code").textContent).toBe("BABYONBU000000E63E7412MX")
+  })
+
+  it('renders bundle_code when type="bundle_code"', () => {
+    render(
+      <LineItemProvider lineItem={buildLineItem({ bundle_code: "BUNDLE-123" })}>
+        <LineItemCode type="bundle_code" data-testid="bundle-code" />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("bundle-code").textContent).toBe("BUNDLE-123")
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemProvider>
+        <LineItemCode>
+          {({ skuCode }) => <span data-testid="custom-code">{skuCode}</span>}
+        </LineItemCode>
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("custom-code").textContent).toBe("BABYONBU000000E63E7412MX")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemCode.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemCode.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemCode } from "#components/line_items/LineItemCode"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemCode } from "#components/line_items/LineItemCode"
 import { buildLineItem, LineItemProvider } from "./helpers"
 
 describe("LineItemCode component", () => {

--- a/packages/react-components/specs/line_items/LineItemField.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemField.spec.tsx
@@ -1,0 +1,38 @@
+import { LineItemField } from "#components/line_items/LineItemField"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { LineItemProvider } from "./helpers"
+
+describe("LineItemField component", () => {
+  it("renders the name attribute from lineItem", () => {
+    render(
+      <LineItemProvider>
+        <LineItemField attribute="name" />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("Baby Onesie").textContent).toBe("Baby Onesie")
+  })
+
+  it("renders with a custom tagElement", () => {
+    render(
+      <LineItemProvider>
+        <LineItemField attribute="name" tagElement="p" />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("Baby Onesie").tagName.toLowerCase()).toBe("p")
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemProvider>
+        <LineItemField attribute="name">
+          {({ attributeValue }) => <span data-testid="custom-field">{String(attributeValue)}</span>}
+        </LineItemField>
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("custom-field").textContent).toBe("Baby Onesie")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemField.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemField.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemField } from "#components/line_items/LineItemField"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemField } from "#components/line_items/LineItemField"
 import { LineItemProvider } from "./helpers"
 
 describe("LineItemField component", () => {

--- a/packages/react-components/specs/line_items/LineItemImage.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemImage.spec.tsx
@@ -1,7 +1,9 @@
-import { LineItemImage } from "#components/line_items/LineItemImage"
-import { defaultGiftCardImgUrl, defaultImgUrl } from "#utils/placeholderImages"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import type { TLineItemImage } from "#components/line_items/LineItemImage"
+import { LineItemImage } from "#components/line_items/LineItemImage"
+import type { ChildrenFunction } from "#typings"
+import { defaultGiftCardImgUrl, defaultImgUrl } from "#utils/placeholderImages"
 import { buildLineItem, LineItemProvider } from "./helpers"
 
 describe("LineItemImage component", () => {
@@ -18,7 +20,7 @@ describe("LineItemImage component", () => {
 
   it("uses default placeholder when no image_url is available", () => {
     render(
-      <LineItemProvider lineItem={buildLineItem({ image_url: undefined as any })}>
+      <LineItemProvider lineItem={buildLineItem({ image_url: undefined })}>
         <LineItemImage />
       </LineItemProvider>
     )
@@ -30,13 +32,11 @@ describe("LineItemImage component", () => {
   it('uses the gift card placeholder when item_type is "gift_cards"', () => {
     render(
       <LineItemProvider
-        lineItem={
-          buildLineItem({
-            item_type: "gift_cards",
-            image_url: undefined as any,
-            sku_code: "GIFTCARD001",
-          })
-        }
+        lineItem={buildLineItem({
+          item_type: "gift_cards",
+          image_url: undefined,
+          sku_code: "GIFTCARD001",
+        })}
       >
         <LineItemImage />
       </LineItemProvider>
@@ -48,7 +48,7 @@ describe("LineItemImage component", () => {
 
   it("uses a custom placeholder when provided for the item type", () => {
     render(
-      <LineItemProvider lineItem={buildLineItem({ image_url: undefined as any })}>
+      <LineItemProvider lineItem={buildLineItem({ image_url: undefined })}>
         <LineItemImage placeholder={{ skus: "https://example.com/custom-placeholder.jpg" }} />
       </LineItemProvider>
     )
@@ -61,7 +61,11 @@ describe("LineItemImage component", () => {
     render(
       <LineItemProvider>
         <LineItemImage>
-          {(({ src }: { src: string }) => <span data-testid="custom-image">{src}</span>) as any}
+          {
+            (({ src }: TLineItemImage) => (
+              <span data-testid="custom-image">{src}</span>
+            )) as ChildrenFunction<TLineItemImage>
+          }
         </LineItemImage>
       </LineItemProvider>
     )

--- a/packages/react-components/specs/line_items/LineItemImage.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemImage.spec.tsx
@@ -1,0 +1,83 @@
+import { LineItemImage } from "#components/line_items/LineItemImage"
+import { defaultGiftCardImgUrl, defaultImgUrl } from "#utils/placeholderImages"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { buildLineItem, LineItemProvider } from "./helpers"
+
+describe("LineItemImage component", () => {
+  it("renders image from image_url", () => {
+    render(
+      <LineItemProvider>
+        <LineItemImage />
+      </LineItemProvider>
+    )
+
+    const image = screen.getByTestId("line-item-image-BABYONBU000000E63E7412MX") as HTMLImageElement
+    expect(image.getAttribute("src")).toBe("https://example.com/img.jpg")
+  })
+
+  it("uses default placeholder when no image_url is available", () => {
+    render(
+      <LineItemProvider lineItem={buildLineItem({ image_url: undefined as any })}>
+        <LineItemImage />
+      </LineItemProvider>
+    )
+
+    const image = screen.getByTestId("line-item-image-BABYONBU000000E63E7412MX") as HTMLImageElement
+    expect(image.getAttribute("src")).toBe(defaultImgUrl)
+  })
+
+  it('uses the gift card placeholder when item_type is "gift_cards"', () => {
+    render(
+      <LineItemProvider
+        lineItem={
+          buildLineItem({
+            item_type: "gift_cards",
+            image_url: undefined as any,
+            sku_code: "GIFTCARD001",
+          })
+        }
+      >
+        <LineItemImage />
+      </LineItemProvider>
+    )
+
+    const image = screen.getByTestId("line-item-image-GIFTCARD001") as HTMLImageElement
+    expect(image.getAttribute("src")).toBe(defaultGiftCardImgUrl)
+  })
+
+  it("uses a custom placeholder when provided for the item type", () => {
+    render(
+      <LineItemProvider lineItem={buildLineItem({ image_url: undefined as any })}>
+        <LineItemImage placeholder={{ skus: "https://example.com/custom-placeholder.jpg" }} />
+      </LineItemProvider>
+    )
+
+    const image = screen.getByTestId("line-item-image-BABYONBU000000E63E7412MX") as HTMLImageElement
+    expect(image.getAttribute("src")).toBe("https://example.com/custom-placeholder.jpg")
+  })
+
+  it("renders children render-prop with src prop", () => {
+    render(
+      <LineItemProvider>
+        <LineItemImage>
+          {(({ src }: { src: string }) => <span data-testid="custom-image">{src}</span>) as any}
+        </LineItemImage>
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("custom-image").textContent).toBe("https://example.com/img.jpg")
+  })
+
+  it("renders fallback attributes when lineItem is missing", () => {
+    render(
+      <LineItemProvider lineItem={undefined}>
+        <LineItemImage />
+      </LineItemProvider>
+    )
+
+    const image = screen.getByTestId("line-item-image-") as HTMLImageElement
+    expect(image.getAttribute("alt")).toBe("")
+    expect(image.getAttribute("src")).toBe(defaultImgUrl)
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemName.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemName.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemName } from "#components/line_items/LineItemName"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemName } from "#components/line_items/LineItemName"
 import { LineItemProvider } from "./helpers"
 
 describe("LineItemName component", () => {

--- a/packages/react-components/specs/line_items/LineItemName.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemName.spec.tsx
@@ -1,0 +1,38 @@
+import { LineItemName } from "#components/line_items/LineItemName"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { LineItemProvider } from "./helpers"
+
+describe("LineItemName component", () => {
+  it("renders lineItem.name in a p tag with data-testid", () => {
+    render(
+      <LineItemProvider>
+        <LineItemName />
+      </LineItemProvider>
+    )
+
+    const name = screen.getByTestId("line-item-name-BABYONBU000000E63E7412MX")
+    expect(name.tagName.toLowerCase()).toBe("p")
+    expect(name.textContent).toBe("Baby Onesie")
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemProvider>
+        <LineItemName>{({ label }) => <span data-testid="custom-name">{label}</span>}</LineItemName>
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("custom-name").textContent).toBe("Baby Onesie")
+  })
+
+  it("renders fallback test id when lineItem is missing", () => {
+    render(
+      <LineItemProvider lineItem={undefined}>
+        <LineItemName />
+      </LineItemProvider>
+    )
+
+    expect(screen.getByTestId("line-item-name-").textContent).toBe("")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemOption.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemOption.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemOption } from "#components/line_items/LineItemOption"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemOption } from "#components/line_items/LineItemOption"
 import { buildLineItemOption, LineItemOptionProvider } from "./helpers"
 
 describe("LineItemOption component", () => {
@@ -72,7 +72,9 @@ describe("LineItemOption component", () => {
 
   it("falls back to an empty string when the option value is undefined", () => {
     render(
-      <LineItemOptionProvider lineItemOption={buildLineItemOption({ options: { Size: undefined } })}>
+      <LineItemOptionProvider
+        lineItemOption={buildLineItemOption({ options: { Size: undefined } })}
+      >
         <LineItemOption name="Size" />
       </LineItemOptionProvider>
     )

--- a/packages/react-components/specs/line_items/LineItemOption.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemOption.spec.tsx
@@ -1,0 +1,82 @@
+import { LineItemOption } from "#components/line_items/LineItemOption"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { buildLineItemOption, LineItemOptionProvider } from "./helpers"
+
+describe("LineItemOption component", () => {
+  it("renders all options when showAll=true", () => {
+    render(
+      <LineItemOptionProvider showAll>
+        <LineItemOption valueClassName="option-value" />
+      </LineItemOptionProvider>
+    )
+
+    expect(screen.getByText("Size:")).toBeDefined()
+    expect(screen.getByText("Color:")).toBeDefined()
+    expect(screen.getByText("M").className).toBe("option-value")
+    expect(screen.getByText("Blue").className).toBe("option-value")
+  })
+
+  it("renders a specific option when the name prop matches", () => {
+    render(
+      <LineItemOptionProvider lineItemOption={buildLineItemOption()}>
+        <LineItemOption name="Size" tagElement="li" tagContainer="ol" />
+      </LineItemOptionProvider>
+    )
+
+    expect(screen.getByText("Size:")).toBeDefined()
+    expect(screen.getByText("M")).toBeDefined()
+  })
+
+  it("renders nothing when the requested option is missing", () => {
+    const { container } = render(
+      <LineItemOptionProvider>
+        <LineItemOption name="Material" />
+      </LineItemOptionProvider>
+    )
+
+    expect(container.querySelector("ul")?.textContent).toBe("")
+  })
+
+  it("renders an empty list when showAll=true and options are missing", () => {
+    const { container } = render(
+      <LineItemOptionProvider lineItemOption={buildLineItemOption({ options: undefined })} showAll>
+        <LineItemOption />
+      </LineItemOptionProvider>
+    )
+
+    expect(container.querySelector("ul")?.textContent).toBe("")
+  })
+
+  it("renders an empty list when showAll=true and options are empty", () => {
+    const { container } = render(
+      <LineItemOptionProvider lineItemOption={buildLineItemOption({ options: {} })} showAll>
+        <LineItemOption />
+      </LineItemOptionProvider>
+    )
+
+    expect(container.querySelector("ul")?.textContent).toBe("")
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemOptionProvider>
+        <LineItemOption>
+          {({ lineItemOption }) => <span data-testid="custom-option">{lineItemOption.name}</span>}
+        </LineItemOption>
+      </LineItemOptionProvider>
+    )
+
+    expect(screen.getByTestId("custom-option").textContent).toBe("Customization")
+  })
+
+  it("falls back to an empty string when the option value is undefined", () => {
+    render(
+      <LineItemOptionProvider lineItemOption={buildLineItemOption({ options: { Size: undefined } })}>
+        <LineItemOption name="Size" />
+      </LineItemOptionProvider>
+    )
+
+    expect(screen.getByText("Size:").parentElement?.textContent).toBe("Size:")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemOptions.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemOptions.spec.tsx
@@ -1,0 +1,81 @@
+import { LineItemOption } from "#components/line_items/LineItemOption"
+import { LineItemOptions } from "#components/line_items/LineItemOptions"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { buildLineItem, buildLineItemOption, LineItemProvider } from "./helpers"
+
+describe("LineItemOptions component", () => {
+  const lineItemOptions = [
+    buildLineItemOption(),
+    buildLineItemOption({
+      name: "Engraving",
+      options: { Text: "Hello" },
+      skuOption: () => ({ id: "sku-opt-2" }),
+    }),
+  ]
+
+  it("renders nothing when line_item_options is empty", () => {
+    const { container } = render(
+      <LineItemProvider lineItem={buildLineItem({ line_item_options: [] })}>
+        <LineItemOptions showAll>
+          <LineItemOption />
+        </LineItemOptions>
+      </LineItemProvider>
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders options with showAll=true", () => {
+    render(
+      <LineItemProvider lineItem={buildLineItem({ line_item_options: lineItemOptions })}>
+        <LineItemOptions showAll titleTagElement="h5" titleClassName="title">
+          <LineItemOption />
+        </LineItemOptions>
+      </LineItemProvider>
+    )
+
+    expect(screen.getByText("Customization")).toBeDefined()
+    expect(screen.getByText("Engraving")).toBeDefined()
+    expect(screen.getByText("Size:")).toBeDefined()
+    expect(screen.getByText("Text:")).toBeDefined()
+  })
+
+  it("filters options by skuOptionId and can hide the title", () => {
+    render(
+      <LineItemProvider lineItem={buildLineItem({ line_item_options: lineItemOptions })}>
+        <LineItemOptions skuOptionId="sku-opt-2" showName={false} className="option-group">
+          <LineItemOption name="Text" />
+        </LineItemOptions>
+      </LineItemProvider>
+    )
+
+    expect(screen.queryByText("Customization")).toBeNull()
+    expect(screen.getByText("Text:")).toBeDefined()
+    expect(screen.getByText("Hello")).toBeDefined()
+  })
+
+  it("renders nothing when lineItem is missing", () => {
+    const { container } = render(
+      <LineItemProvider lineItem={undefined}>
+        <LineItemOptions showAll>
+          <LineItemOption />
+        </LineItemOptions>
+      </LineItemProvider>
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("falls back to an empty array when line_item_options is undefined", () => {
+    const { container } = render(
+      <LineItemProvider lineItem={buildLineItem({ line_item_options: undefined })}>
+        <LineItemOptions showAll>
+          <LineItemOption />
+        </LineItemOptions>
+      </LineItemProvider>
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemOptions.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemOptions.spec.tsx
@@ -1,7 +1,7 @@
-import { LineItemOption } from "#components/line_items/LineItemOption"
-import { LineItemOptions } from "#components/line_items/LineItemOptions"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemOption } from "#components/line_items/LineItemOption"
+import { LineItemOptions } from "#components/line_items/LineItemOptions"
 import { buildLineItem, buildLineItemOption, LineItemProvider } from "./helpers"
 
 describe("LineItemOptions component", () => {
@@ -10,7 +10,7 @@ describe("LineItemOptions component", () => {
     buildLineItemOption({
       name: "Engraving",
       options: { Text: "Hello" },
-      skuOption: () => ({ id: "sku-opt-2" }),
+      sku_option: { id: "sku-opt-2" },
     }),
   ]
 

--- a/packages/react-components/specs/line_items/LineItemQuantity.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemQuantity.spec.tsx
@@ -1,0 +1,77 @@
+import { LineItemQuantity } from "#components/line_items/LineItemQuantity"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { LineItemProvider, LineItemsProvider } from "./helpers"
+
+describe("LineItemQuantity component", () => {
+  it("renders a select with the current quantity selected", () => {
+    render(
+      <LineItemsProvider>
+        <LineItemProvider>
+          <LineItemQuantity />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    expect((screen.getByTestId("BABYONBU000000E63E7412MX") as HTMLSelectElement).value).toBe("2")
+  })
+
+  it("renders a span with quantity when readonly=true", () => {
+    render(
+      <LineItemsProvider>
+        <LineItemProvider>
+          <LineItemQuantity readonly data-testid="readonly-quantity" />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("readonly-quantity").textContent).toBe("2")
+  })
+
+  it("calls updateLineItem from context when select changes", () => {
+    const mockUpdate = vi.fn()
+
+    render(
+      <LineItemsProvider updateLineItem={mockUpdate}>
+        <LineItemProvider>
+          <LineItemQuantity hasExternalPrice />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    fireEvent.change(screen.getByTestId("BABYONBU000000E63E7412MX"), {
+      target: { value: "4" },
+    })
+
+    expect(mockUpdate).toHaveBeenCalledWith("li_1", 4, true)
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemsProvider>
+        <LineItemProvider>
+          <LineItemQuantity>
+            {({ quantity }) => <span data-testid="custom-quantity">{quantity}</span>}
+          </LineItemQuantity>
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("custom-quantity").textContent).toBe("2")
+  })
+
+  it("renders an empty title and skips updates when lineItem is missing", () => {
+    render(
+      <LineItemsProvider updateLineItem={vi.fn()}>
+        <LineItemProvider lineItem={undefined}>
+          <LineItemQuantity data-testid="missing-line-item-quantity" />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    const select = screen.getByTestId("missing-line-item-quantity") as HTMLSelectElement
+    fireEvent.change(select, { target: { value: "3" } })
+
+    expect(select.getAttribute("title")).toBe("")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemQuantity.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemQuantity.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemQuantity } from "#components/line_items/LineItemQuantity"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
+import { LineItemQuantity } from "#components/line_items/LineItemQuantity"
 import { LineItemProvider, LineItemsProvider } from "./helpers"
 
 describe("LineItemQuantity component", () => {

--- a/packages/react-components/specs/line_items/LineItemRemoveLink.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemRemoveLink.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemRemoveLink } from "#components/line_items/LineItemRemoveLink"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
+import { LineItemRemoveLink } from "#components/line_items/LineItemRemoveLink"
 import { LineItemProvider, LineItemsProvider } from "./helpers"
 
 describe("LineItemRemoveLink component", () => {

--- a/packages/react-components/specs/line_items/LineItemRemoveLink.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemRemoveLink.spec.tsx
@@ -1,0 +1,90 @@
+import { LineItemRemoveLink } from "#components/line_items/LineItemRemoveLink"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { LineItemProvider, LineItemsProvider } from "./helpers"
+
+describe("LineItemRemoveLink component", () => {
+  it('renders a "Remove" link with data-testid', () => {
+    render(
+      <LineItemsProvider>
+        <LineItemProvider>
+          <LineItemRemoveLink />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("line-item-remove-link-BABYONBU000000E63E7412MX").textContent).toBe(
+      "Remove"
+    )
+  })
+
+  it("calls deleteLineItem from context on click", () => {
+    const mockDelete = vi.fn()
+
+    render(
+      <LineItemsProvider deleteLineItem={mockDelete}>
+        <LineItemProvider>
+          <LineItemRemoveLink />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    fireEvent.click(screen.getByTestId("line-item-remove-link-BABYONBU000000E63E7412MX"))
+
+    expect(mockDelete).toHaveBeenCalledWith("li_1")
+  })
+
+  it("calls onClick prop on click", () => {
+    const onClick = vi.fn()
+
+    render(
+      <LineItemsProvider>
+        <LineItemProvider>
+          <LineItemRemoveLink onClick={onClick} />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    fireEvent.click(screen.getByTestId("line-item-remove-link-BABYONBU000000E63E7412MX"))
+
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it("renders a custom label", () => {
+    render(
+      <LineItemsProvider>
+        <LineItemProvider>
+          <LineItemRemoveLink label="Delete item" />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByText("Delete item")).toBeDefined()
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemsProvider>
+        <LineItemProvider>
+          <LineItemRemoveLink label="Delete item">
+            {({ label }) => <span data-testid="custom-remove-link">{label}</span>}
+          </LineItemRemoveLink>
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("custom-remove-link").textContent).toBe("Delete item")
+  })
+
+  it("renders a fallback test id when lineItem is missing", () => {
+    render(
+      <LineItemsProvider>
+        <LineItemProvider lineItem={undefined}>
+          <LineItemRemoveLink />
+        </LineItemProvider>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("line-item-remove-link-").textContent).toBe("Remove")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItems.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItems.spec.tsx
@@ -1,6 +1,6 @@
-import { render, screen, act } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import { type ReactNode, useContext } from "react"
-import { vi, beforeEach, describe, it, expect } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { LineItems } from "#components/line_items/LineItems"
 import CommerceLayerContext from "#context/CommerceLayerContext"
 import LineItemContext from "#context/LineItemContext"

--- a/packages/react-components/specs/line_items/LineItemsCount.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemsCount.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemsCount } from "#components/line_items/LineItemsCount"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemsCount } from "#components/line_items/LineItemsCount"
 import { buildLineItem, LineItemsProvider } from "./helpers"
 
 describe("LineItemsCount component", () => {
@@ -45,7 +45,9 @@ describe("LineItemsCount component", () => {
   it("renders children render-prop", () => {
     render(
       <LineItemsProvider lineItems={lineItems}>
-        <LineItemsCount>{({ quantity }) => <span data-testid="custom-count">{quantity}</span>}</LineItemsCount>
+        <LineItemsCount>
+          {({ quantity }) => <span data-testid="custom-count">{quantity}</span>}
+        </LineItemsCount>
       </LineItemsProvider>
     )
 

--- a/packages/react-components/specs/line_items/LineItemsCount.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemsCount.spec.tsx
@@ -1,0 +1,54 @@
+import { LineItemsCount } from "#components/line_items/LineItemsCount"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { buildLineItem, LineItemsProvider } from "./helpers"
+
+describe("LineItemsCount component", () => {
+  const lineItems = [
+    buildLineItem({ id: "sku_1", item_type: "skus", quantity: 2 }),
+    buildLineItem({ id: "gift_1", item_type: "gift_cards", quantity: 1, total_amount_cents: 1000 }),
+    buildLineItem({ id: "bundle_1", item_type: "bundles", quantity: 1 }),
+    buildLineItem({ id: "adj_1", item_type: "adjustments", quantity: 3 }),
+    buildLineItem({ id: "shipment_1", item_type: "shipments", quantity: 10 }),
+  ]
+
+  it("renders count of skus, gift_cards, bundles, and adjustments", () => {
+    render(
+      <LineItemsProvider lineItems={lineItems}>
+        <LineItemsCount data-testid="line-items-count" />
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("line-items-count").textContent).toBe("7")
+  })
+
+  it("renders 0 when lineItems is empty", () => {
+    render(
+      <LineItemsProvider lineItems={[]}>
+        <LineItemsCount data-testid="empty-line-items-count" />
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("empty-line-items-count").textContent).toBe("0")
+  })
+
+  it("filters by typeAccepted prop", () => {
+    render(
+      <LineItemsProvider lineItems={lineItems}>
+        <LineItemsCount typeAccepted={["gift_cards"]} data-testid="filtered-line-items-count" />
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("filtered-line-items-count").textContent).toBe("1")
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemsProvider lineItems={lineItems}>
+        <LineItemsCount>{({ quantity }) => <span data-testid="custom-count">{quantity}</span>}</LineItemsCount>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("custom-count").textContent).toBe("7")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemsEmpty.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemsEmpty.spec.tsx
@@ -1,0 +1,58 @@
+import { LineItemsEmpty } from "#components/line_items/LineItemsEmpty"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { LineItemsProvider, MOCK_LINE_ITEM } from "./helpers"
+
+describe("LineItemsEmpty component", () => {
+  it('renders default text "Your shopping bag is empty" when lineItems is empty', () => {
+    render(
+      <LineItemsProvider lineItems={[]}>
+        <LineItemsEmpty />
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByText("Your shopping bag is empty")).toBeDefined()
+  })
+
+  it("renders custom text when lineItems is empty", () => {
+    render(
+      <LineItemsProvider lineItems={[]}>
+        <LineItemsEmpty text="Nothing here" />
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByText("Nothing here")).toBeDefined()
+  })
+
+  it("renders nothing when lineItems has items", () => {
+    const { container } = render(
+      <LineItemsProvider lineItems={[MOCK_LINE_ITEM]}>
+        <LineItemsEmpty />
+      </LineItemsProvider>
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders nothing when lineItems is null or undefined", () => {
+    const { container } = render(
+      <LineItemsProvider lineItems={undefined}>
+        <LineItemsEmpty />
+      </LineItemsProvider>
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders children render-prop", () => {
+    render(
+      <LineItemsProvider lineItems={[]}>
+        <LineItemsEmpty>
+          {({ quantity, text }) => <span data-testid="custom-empty">{`${quantity}:${text}`}</span>}
+        </LineItemsEmpty>
+      </LineItemsProvider>
+    )
+
+    expect(screen.getByTestId("custom-empty").textContent).toBe("0:Your shopping bag is empty")
+  })
+})

--- a/packages/react-components/specs/line_items/LineItemsEmpty.spec.tsx
+++ b/packages/react-components/specs/line_items/LineItemsEmpty.spec.tsx
@@ -1,6 +1,6 @@
-import { LineItemsEmpty } from "#components/line_items/LineItemsEmpty"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+import { LineItemsEmpty } from "#components/line_items/LineItemsEmpty"
 import { LineItemsProvider, MOCK_LINE_ITEM } from "./helpers"
 
 describe("LineItemsEmpty component", () => {

--- a/packages/react-components/specs/line_items/helpers.tsx
+++ b/packages/react-components/specs/line_items/helpers.tsx
@@ -1,16 +1,17 @@
-import LineItemContext from "#context/LineItemContext"
+import type { LineItem, LineItemOption } from "@commercelayer/sdk"
+import type { ReactNode } from "react"
 import LineItemChildrenContext from "#context/LineItemChildrenContext"
+import LineItemContext from "#context/LineItemContext"
 import LineItemOptionChildrenContext from "#context/LineItemOptionChildrenContext"
 import ShipmentChildrenContext from "#context/ShipmentChildrenContext"
-import type { ReactNode } from "react"
 
-export const MOCK_LINE_ITEM: any = {
+export const MOCK_LINE_ITEM: Partial<LineItem> = {
   id: "li_1",
   item_type: "skus",
   quantity: 2,
   name: "Baby Onesie",
   sku_code: "BABYONBU000000E63E7412MX",
-  bundle_code: null,
+  bundle_code: undefined,
   image_url: "https://example.com/img.jpg",
   formatted_total_amount: "€24.00",
   total_amount_float: 24.0,
@@ -21,7 +22,7 @@ export const MOCK_LINE_ITEM: any = {
   line_item_options: [],
 }
 
-export function buildLineItem(overrides: Record<string, any> = {}) {
+export function buildLineItem(overrides: Partial<LineItem> = {}): Partial<LineItem> {
   return {
     ...MOCK_LINE_ITEM,
     ...overrides,
@@ -35,15 +36,16 @@ export function buildLineItemOption(overrides: Record<string, unknown> = {}) {
       Size: "M",
       Color: "Blue",
     },
-    skuOption: () => ({ id: "sku-opt-1" }),
+    sku_option: { id: "sku-opt-1" },
     ...overrides,
   }
 }
 
-export function LineItemProvider(props: { children: ReactNode; lineItem?: any }) {
-  const lineItem = Object.prototype.hasOwnProperty.call(props, "lineItem")
-    ? props.lineItem
-    : MOCK_LINE_ITEM
+export function LineItemProvider(props: {
+  children: ReactNode
+  lineItem?: Partial<LineItem> | null
+}) {
+  const lineItem = "lineItem" in props ? props.lineItem : MOCK_LINE_ITEM
 
   return (
     <LineItemChildrenContext.Provider value={{ lineItem }}>
@@ -54,18 +56,20 @@ export function LineItemProvider(props: { children: ReactNode; lineItem?: any })
 
 export function LineItemsProvider(props: {
   children: ReactNode
-  lineItems?: any
-  updateLineItem?: any
-  deleteLineItem?: any
+  lineItems?: Array<Partial<LineItem>>
+  updateLineItem?: (
+    lineItemId: string,
+    quantity?: number,
+    hasExternalPrice?: boolean
+  ) => Promise<void>
+  deleteLineItem?: (lineItemId: string) => Promise<void>
 }) {
-  const lineItems = Object.prototype.hasOwnProperty.call(props, "lineItems")
-    ? props.lineItems
-    : [MOCK_LINE_ITEM]
+  const lineItems = "lineItems" in props ? props.lineItems : [MOCK_LINE_ITEM]
 
   return (
     <LineItemContext.Provider
       value={{
-        lineItems,
+        lineItems: lineItems as LineItem[],
         updateLineItem: props.updateLineItem,
         deleteLineItem: props.deleteLineItem,
       }}
@@ -77,11 +81,11 @@ export function LineItemsProvider(props: {
 
 export function LineItemOptionProvider({
   children,
-  lineItemOption = buildLineItemOption(),
+  lineItemOption = buildLineItemOption() as unknown as Partial<LineItemOption>,
   showAll,
 }: {
   children: ReactNode
-  lineItemOption?: any
+  lineItemOption?: Partial<LineItemOption>
   showAll?: boolean
 }) {
   return (
@@ -96,7 +100,7 @@ export function ShipmentProvider({
   lineItems = [],
 }: {
   children: ReactNode
-  lineItems?: any[]
+  lineItems?: Array<LineItem | null | undefined>
 }) {
   return (
     <ShipmentChildrenContext.Provider value={{ keyNumber: 0, lineItems }}>

--- a/packages/react-components/specs/line_items/helpers.tsx
+++ b/packages/react-components/specs/line_items/helpers.tsx
@@ -1,0 +1,106 @@
+import LineItemContext from "#context/LineItemContext"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
+import LineItemOptionChildrenContext from "#context/LineItemOptionChildrenContext"
+import ShipmentChildrenContext from "#context/ShipmentChildrenContext"
+import type { ReactNode } from "react"
+
+export const MOCK_LINE_ITEM: any = {
+  id: "li_1",
+  item_type: "skus",
+  quantity: 2,
+  name: "Baby Onesie",
+  sku_code: "BABYONBU000000E63E7412MX",
+  bundle_code: null,
+  image_url: "https://example.com/img.jpg",
+  formatted_total_amount: "€24.00",
+  total_amount_float: 24.0,
+  total_amount_cents: 2400,
+  formatted_unit_amount: "€12.00",
+  unit_amount_float: 12.0,
+  unit_amount_cents: 1200,
+  line_item_options: [],
+}
+
+export function buildLineItem(overrides: Record<string, any> = {}) {
+  return {
+    ...MOCK_LINE_ITEM,
+    ...overrides,
+  }
+}
+
+export function buildLineItemOption(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Customization",
+    options: {
+      Size: "M",
+      Color: "Blue",
+    },
+    skuOption: () => ({ id: "sku-opt-1" }),
+    ...overrides,
+  }
+}
+
+export function LineItemProvider(props: { children: ReactNode; lineItem?: any }) {
+  const lineItem = Object.prototype.hasOwnProperty.call(props, "lineItem")
+    ? props.lineItem
+    : MOCK_LINE_ITEM
+
+  return (
+    <LineItemChildrenContext.Provider value={{ lineItem }}>
+      {props.children}
+    </LineItemChildrenContext.Provider>
+  )
+}
+
+export function LineItemsProvider(props: {
+  children: ReactNode
+  lineItems?: any
+  updateLineItem?: any
+  deleteLineItem?: any
+}) {
+  const lineItems = Object.prototype.hasOwnProperty.call(props, "lineItems")
+    ? props.lineItems
+    : [MOCK_LINE_ITEM]
+
+  return (
+    <LineItemContext.Provider
+      value={{
+        lineItems,
+        updateLineItem: props.updateLineItem,
+        deleteLineItem: props.deleteLineItem,
+      }}
+    >
+      {props.children}
+    </LineItemContext.Provider>
+  )
+}
+
+export function LineItemOptionProvider({
+  children,
+  lineItemOption = buildLineItemOption(),
+  showAll,
+}: {
+  children: ReactNode
+  lineItemOption?: any
+  showAll?: boolean
+}) {
+  return (
+    <LineItemOptionChildrenContext.Provider value={{ lineItemOption, showAll }}>
+      {children}
+    </LineItemOptionChildrenContext.Provider>
+  )
+}
+
+export function ShipmentProvider({
+  children,
+  lineItems = [],
+}: {
+  children: ReactNode
+  lineItems?: any[]
+}) {
+  return (
+    <ShipmentChildrenContext.Provider value={{ keyNumber: 0, lineItems }}>
+      {children}
+    </ShipmentChildrenContext.Provider>
+  )
+}

--- a/packages/react-components/src/components/line_items/LineItem.tsx
+++ b/packages/react-components/src/components/line_items/LineItem.tsx
@@ -26,7 +26,7 @@ export function LineItem(props: Props): JSX.Element {
   const items = shipmentLineItems && shipmentLineItems?.length > 0 ? shipmentLineItems : lineItems
   const components = items
     ?.filter((l) => l?.item_type === type)
-    .map((lineItem, k, check) => {
+    .map((lineItem, k, check): JSX.Element | null => {
       if (
         lineItem?.item_type === "bundles" &&
         k > 0 &&
@@ -35,7 +35,7 @@ export function LineItem(props: Props): JSX.Element {
         return null
       if (
         lineItem?.item_type === "gift_cards" &&
-        lineItem?.total_amount_cents &&
+        lineItem?.total_amount_cents != null &&
         lineItem?.total_amount_cents <= 0
       )
         return null

--- a/packages/react-components/src/components/line_items/LineItem.tsx
+++ b/packages/react-components/src/components/line_items/LineItem.tsx
@@ -1,8 +1,8 @@
-import { useContext, type JSX } from "react"
-import LineItemContext from "#context/LineItemContext"
+import { type JSX, useContext } from "react"
 import LineItemChildrenContext, {
   type InitialLineItemChildrenContext,
 } from "#context/LineItemChildrenContext"
+import LineItemContext from "#context/LineItemContext"
 import ShipmentChildrenContext from "#context/ShipmentChildrenContext"
 
 export type TLineItem =

--- a/packages/react-components/src/components/line_items/LineItemAmount.tsx
+++ b/packages/react-components/src/components/line_items/LineItemAmount.tsx
@@ -1,8 +1,8 @@
-import { useContext, useMemo, type JSX } from "react"
-import getAmount from "#utils/getAmount"
-import LineItemChildrenContext from "#context/LineItemChildrenContext"
+import { type JSX, useContext, useMemo } from "react"
 import Parent from "#components/utils/Parent"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import type { BaseAmountComponent, BasePriceType } from "#typings/index"
+import getAmount from "#utils/getAmount"
 
 type Props = BaseAmountComponent & {
   type?: BasePriceType

--- a/packages/react-components/src/components/line_items/LineItemAmount.tsx
+++ b/packages/react-components/src/components/line_items/LineItemAmount.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, type JSX } from "react"
+import { useContext, useMemo, type JSX } from "react"
 import getAmount from "#utils/getAmount"
 import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import Parent from "#components/utils/Parent"
@@ -11,21 +11,10 @@ type Props = BaseAmountComponent & {
 export function LineItemAmount(props: Props): JSX.Element {
   const { format = "formatted", type = "total", ...p } = props
   const { lineItem } = useContext(LineItemChildrenContext)
-  const [price, setPrice] = useState("")
-  useEffect(() => {
-    if (lineItem) {
-      const p = getAmount({
-        base: "amount",
-        type,
-        format,
-        obj: lineItem,
-      })
-      setPrice(p)
-    }
-    return (): void => {
-      setPrice("")
-    }
-  }, [lineItem])
+  const price = useMemo(
+    () => (lineItem ? getAmount({ base: "amount", type, format, obj: lineItem }) : ""),
+    [lineItem, type, format]
+  )
   const parentProps = {
     price,
     ...p,

--- a/packages/react-components/src/components/line_items/LineItemCode.tsx
+++ b/packages/react-components/src/components/line_items/LineItemCode.tsx
@@ -1,7 +1,7 @@
-import { useContext, type JSX } from "react"
-import LineItemChildrenContext from "#context/LineItemChildrenContext"
-import Parent from "#components/utils/Parent"
 import type { LineItem } from "@commercelayer/sdk"
+import { type JSX, useContext } from "react"
+import Parent from "#components/utils/Parent"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import type { ChildrenFunction } from "#typings/index"
 
 export interface TLineItemCode extends Omit<Props, "children"> {

--- a/packages/react-components/src/components/line_items/LineItemField.tsx
+++ b/packages/react-components/src/components/line_items/LineItemField.tsx
@@ -1,12 +1,11 @@
-import LineItemChildrenContext from "#context/LineItemChildrenContext"
-import type { ConditionalElement } from "#typings"
+import type { JSX } from "react"
 import GenericFieldComponent, {
   type TGenericChildrenProps,
   type TResourceKey,
   type TResources,
 } from "#components/utils/GenericFieldComponent"
-
-import type { JSX } from "react"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
+import type { ConditionalElement } from "#typings"
 
 type LineItemFieldChildrenProps = TGenericChildrenProps<TResources["LineItem"]>
 

--- a/packages/react-components/src/components/line_items/LineItemImage.tsx
+++ b/packages/react-components/src/components/line_items/LineItemImage.tsx
@@ -39,7 +39,7 @@ export function LineItemImage(props: Props): JSX.Element | null {
   }
   return children ? (
     <Parent {...parenProps}>{children}</Parent>
-  ) : !src ? null : (
+  ) : (
     <img
       data-testid={`line-item-image-${lineItem?.sku_code ?? ""}`}
       alt={lineItem?.name ?? ""}

--- a/packages/react-components/src/components/line_items/LineItemImage.tsx
+++ b/packages/react-components/src/components/line_items/LineItemImage.tsx
@@ -1,9 +1,9 @@
-import { useContext, type JSX } from "react"
-import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import type { LineItem } from "@commercelayer/sdk"
+import { type JSX, useContext } from "react"
+import Parent from "#components/utils/Parent"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import type { ChildrenFunction } from "#typings"
 import { defaultGiftCardImgUrl, defaultImgUrl } from "#utils/placeholderImages"
-import Parent from "#components/utils/Parent"
 import type { TLineItem } from "./LineItem"
 
 export interface TLineItemImage extends Omit<Props, "children"> {

--- a/packages/react-components/src/components/line_items/LineItemName.tsx
+++ b/packages/react-components/src/components/line_items/LineItemName.tsx
@@ -1,7 +1,7 @@
-import { useContext, type JSX } from "react"
-import LineItemChildrenContext from "#context/LineItemChildrenContext"
-import Parent from "#components/utils/Parent"
 import type { LineItem } from "@commercelayer/sdk"
+import { type JSX, useContext } from "react"
+import Parent from "#components/utils/Parent"
+import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import type { ChildrenFunction } from "#typings/index"
 
 export interface TLineItemName extends Omit<Props, "children"> {

--- a/packages/react-components/src/components/line_items/LineItemOption.tsx
+++ b/packages/react-components/src/components/line_items/LineItemOption.tsx
@@ -1,9 +1,8 @@
-import { useContext, type CSSProperties, type JSX } from "react"
+import { type CSSProperties, type ElementType, type JSX, useContext } from "react"
 import LineItemOptionChildrenContext from "#context/LineItemOptionChildrenContext"
 import Parent from "#components/utils/Parent"
 import type { LineItemOption as LineItemOptionType } from "@commercelayer/sdk"
 import type { ChildrenFunction } from "#typings/index"
-import isJSON from "#utils/isJSON"
 
 export interface TLineItemOption extends Omit<Props, "children"> {
   lineItemOption: LineItemOptionType
@@ -36,27 +35,27 @@ export function LineItemOption(props: Props): JSX.Element {
     ...props,
     lineItemOption,
   }
-  const TagElement = tagElement as any
-  const TagContainer = tagContainer
+  const TagElement: ElementType = tagElement
+  const TagContainer: ElementType = tagContainer
+  const optionEntries = Object.entries(lineItemOption?.options ?? {})
   const label = name != null ? lineItemOption?.options?.[name] : ""
-  const components =
-    showAll && isJSON(JSON.stringify(lineItemOption?.options)) ? (
-      Object.entries(lineItemOption?.options ?? {}).map(([key, value]) => {
-        return (
-          <TagElement key={key} {...p}>
-            {`${key}:`}
-            <span className={valueClassName}>{`${value as string}`}</span>
-          </TagElement>
-        )
-      })
-    ) : name != null && lineItemOption?.options != null && name in lineItemOption.options ? (
-      <TagElement key={key} {...p}>
-        {`${name}:`}
-        <span className={valueClassName} {...p}>
-          {label ?? ""}
-        </span>
-      </TagElement>
-    ) : null
+  const components = showAll ? (
+    optionEntries.map(([key, value]) => {
+      return (
+        <TagElement key={key} {...p}>
+          {`${key}:`}
+          <span className={valueClassName}>{`${value as string}`}</span>
+        </TagElement>
+      )
+    })
+  ) : name != null && lineItemOption?.options != null && name in lineItemOption.options ? (
+    <TagElement key={key} {...p}>
+      {`${name}:`}
+      <span className={valueClassName} {...p}>
+        {label ?? ""}
+      </span>
+    </TagElement>
+  ) : null
   return children ? (
     <Parent {...parentProps}>{props.children}</Parent>
   ) : (

--- a/packages/react-components/src/components/line_items/LineItemOption.tsx
+++ b/packages/react-components/src/components/line_items/LineItemOption.tsx
@@ -1,7 +1,7 @@
-import { type CSSProperties, type ElementType, type JSX, useContext } from "react"
-import LineItemOptionChildrenContext from "#context/LineItemOptionChildrenContext"
-import Parent from "#components/utils/Parent"
 import type { LineItemOption as LineItemOptionType } from "@commercelayer/sdk"
+import { type CSSProperties, type ElementType, type JSX, useContext } from "react"
+import Parent from "#components/utils/Parent"
+import LineItemOptionChildrenContext from "#context/LineItemOptionChildrenContext"
 import type { ChildrenFunction } from "#typings/index"
 
 export interface TLineItemOption extends Omit<Props, "children"> {

--- a/packages/react-components/src/components/line_items/LineItemOptions.tsx
+++ b/packages/react-components/src/components/line_items/LineItemOptions.tsx
@@ -40,7 +40,7 @@ export function LineItemOptions(props: Props): JSX.Element {
   const options = lineItemOptions
     .filter((o) => {
       if (showAll) return true
-      return (o as any).skuOption?.()?.id === skuOptionId
+      return o.sku_option?.id === skuOptionId
     })
     .map((o, k) => {
       const showTitle = showName ? (
@@ -51,7 +51,7 @@ export function LineItemOptions(props: Props): JSX.Element {
         showAll,
       }
       return (
-        <div className={className} key={k} {...p}>
+        <div className={className} key={o.id ?? k} {...p}>
           {showTitle}
           <LineItemOptionChildrenContext.Provider value={valueProps}>
             {children}

--- a/packages/react-components/src/components/line_items/LineItemOptions.tsx
+++ b/packages/react-components/src/components/line_items/LineItemOptions.tsx
@@ -1,4 +1,4 @@
-import { useContext, type ReactNode, type JSX } from "react"
+import { type ElementType, type JSX, type ReactNode, useContext } from "react"
 import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import LineItemOptionChildrenContext, {
   type TLineItemOptions,
@@ -36,12 +36,11 @@ export function LineItemOptions(props: Props): JSX.Element {
   } = props
   const { lineItem } = useContext(LineItemChildrenContext)
   const lineItemOptions = lineItem != null ? lineItem?.line_item_options || [] : []
-  const TitleTagElement = titleTagElement as any
+  const TitleTagElement: ElementType = titleTagElement
   const options = lineItemOptions
     .filter((o) => {
       if (showAll) return true
-      // @ts-expect-error no type
-      return o.skuOption().id === skuOptionId
+      return (o as any).skuOption?.()?.id === skuOptionId
     })
     .map((o, k) => {
       const showTitle = showName ? (

--- a/packages/react-components/src/components/line_items/LineItemQuantity.tsx
+++ b/packages/react-components/src/components/line_items/LineItemQuantity.tsx
@@ -1,9 +1,9 @@
-import { useContext, type ReactNode, type JSX } from "react"
+import type { LineItem } from "@commercelayer/sdk"
+import { type JSX, type ReactNode, useContext } from "react"
+import Parent from "#components/utils/Parent"
 import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import LineItemContext from "#context/LineItemContext"
-import Parent from "#components/utils/Parent"
 import type { ChildrenFunction } from "#typings"
-import type { LineItem } from "@commercelayer/sdk"
 
 interface ChildrenProps extends Omit<Props, "children"> {
   quantity: number

--- a/packages/react-components/src/components/line_items/LineItemRemoveLink.tsx
+++ b/packages/react-components/src/components/line_items/LineItemRemoveLink.tsx
@@ -1,18 +1,18 @@
-import { useContext, type PropsWithoutRef, type JSX } from "react"
+import type { LineItem } from "@commercelayer/sdk"
+import { type JSX, type PropsWithoutRef, useContext } from "react"
+import Parent from "#components/utils/Parent"
 import LineItemChildrenContext from "#context/LineItemChildrenContext"
 import LineItemContext from "#context/LineItemContext"
-import Parent from "#components/utils/Parent"
 import type { ChildrenFunction } from "#typings/index"
 import useCustomContext from "#utils/hooks/useCustomContext"
-import type { LineItem } from "@commercelayer/sdk"
 
 interface ChildrenProps extends Omit<Props, "children"> {
-  handleRemove: (event: React.MouseEvent<HTMLAnchorElement>) => void
+  handleRemove: (event: React.MouseEvent<HTMLButtonElement>) => void
   label?: string
   lineItem?: LineItem
 }
 
-interface Props extends PropsWithoutRef<Omit<JSX.IntrinsicElements["a"], "children">> {
+interface Props extends PropsWithoutRef<Omit<JSX.IntrinsicElements["button"], "children">> {
   children?: ChildrenFunction<ChildrenProps>
   label?: string
 }
@@ -26,7 +26,7 @@ export function LineItemRemoveLink(props: Props): JSX.Element {
     key: "lineItem",
   })
   const { deleteLineItem } = useContext(LineItemContext)
-  const handleRemove = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+  const handleRemove = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.preventDefault()
     if (deleteLineItem != null && lineItem != null) deleteLineItem(lineItem.id)
     if (onClick != null) onClick(e)
@@ -39,14 +39,14 @@ export function LineItemRemoveLink(props: Props): JSX.Element {
   return props.children ? (
     <Parent {...parentProps}>{props.children}</Parent>
   ) : (
-    <a
+    <button
+      type="button"
       data-testid={`line-item-remove-link-${lineItem?.sku_code ?? ""}`}
       {...props}
-      href="#"
       onClick={handleRemove}
     >
       {label}
-    </a>
+    </button>
   )
 }
 

--- a/packages/react-components/src/components/line_items/LineItems.tsx
+++ b/packages/react-components/src/components/line_items/LineItems.tsx
@@ -48,7 +48,9 @@ export function LineItems({
   } = useLineItems({ accessToken, orderId })
 
   const lineItems =
-    types != null ? allLineItems.filter((li) => types.includes(li.item_type as TLineItem)) : allLineItems
+    types != null
+      ? allLineItems.filter((li) => types.includes(li.item_type as TLineItem))
+      : allLineItems
 
   const errors: BaseError[] = error
     ? [{ code: "INTERNAL_SERVER_ERROR", message: error, resource: "line_items" }]

--- a/packages/react-components/src/components/line_items/LineItemsContainer.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsContainer.tsx
@@ -1,17 +1,17 @@
-import { useEffect, useReducer, useContext, type JSX } from "react"
+import { type JSX, useContext, useEffect, useReducer } from "react"
+import CommerceLayerContext from "#context/CommerceLayerContext"
+import LineItemContext, { type LineItemContextValue } from "#context/LineItemContext"
+import OrderContext from "#context/OrderContext"
 import lineItemReducer, {
+  deleteLineItem,
   lineItemInitialState,
   updateLineItem,
-  deleteLineItem,
 } from "#reducers/LineItemReducer"
-import OrderContext from "#context/OrderContext"
-import LineItemContext, { type LineItemContextValue } from "#context/LineItemContext"
-import CommerceLayerContext from "#context/CommerceLayerContext"
 import type { DefaultChildrenType } from "#typings/globals"
 
 interface Props {
   children: DefaultChildrenType
-  filters?: Record<string, any>
+  filters?: Record<string, unknown>
   loader?: JSX.Element
 }
 
@@ -48,7 +48,7 @@ export function LineItemsContainer(props: Props): JSX.Element {
         },
       })
     }
-  }, [include, includeLoaded])
+  }, [include, includeLoaded, addResourceToInclude])
   useEffect(() => {
     if (order?.line_items) {
       dispatch({

--- a/packages/react-components/src/components/line_items/LineItemsCount.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsCount.tsx
@@ -1,8 +1,8 @@
-import { useMemo, type JSX } from "react"
+import { type JSX, useMemo } from "react"
 import Parent from "#components/utils/Parent"
-import getLineItemsCount, { type TypeAccepted } from "#utils/getLineItemsCount"
 import LineItemContext from "#context/LineItemContext"
 import type { ChildrenFunction } from "#typings/index"
+import getLineItemsCount, { type TypeAccepted } from "#utils/getLineItemsCount"
 import useCustomContext from "#utils/hooks/useCustomContext"
 
 interface ChildrenProps extends Omit<Props, "children"> {

--- a/packages/react-components/src/components/line_items/LineItemsCount.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsCount.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type JSX } from "react"
+import { useMemo, type JSX } from "react"
 import Parent from "#components/utils/Parent"
 import getLineItemsCount, { type TypeAccepted } from "#utils/getLineItemsCount"
 import LineItemContext from "#context/LineItemContext"
@@ -22,19 +22,10 @@ export function LineItemsCount(props: Props): JSX.Element {
     currentComponentName: "LineItemsCount",
     key: "lineItems",
   })
-  const [quantity, setQuantity] = useState(0)
-  useEffect(() => {
-    if (lineItems && lineItems.length > 0) {
-      const qty = getLineItemsCount({
-        lineItems: lineItems || [],
-        typeAccepted,
-      })
-      setQuantity(qty)
-    }
-    return (): void => {
-      setQuantity(0)
-    }
-  }, [lineItems, typeAccepted])
+  const quantity = useMemo(
+    () => (lineItems && lineItems.length > 0 ? getLineItemsCount({ lineItems, typeAccepted }) : 0),
+    [lineItems, typeAccepted]
+  )
   const parentProps = {
     quantity,
     typeAccepted,

--- a/packages/react-components/src/components/line_items/LineItemsEmpty.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsEmpty.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useEffect, type JSX } from "react"
+import { useContext, useMemo, type JSX } from "react"
 import Parent from "#components/utils/Parent"
 import getLineItemsCount from "#utils/getLineItemsCount"
 import LineItemContext from "#context/LineItemContext"
@@ -17,21 +17,11 @@ interface Props extends Omit<JSX.IntrinsicElements["span"], "children"> {
 export function LineItemsEmpty(props: Props): JSX.Element | null {
   const { children, text = "Your shopping bag is empty", ...p } = props
   const { lineItems } = useContext(LineItemContext)
-  const [quantity, setQuantity] = useState<undefined | number>()
-  const emptyText = quantity === 0 ? <span {...p}>{text}</span> : null
-  useEffect(() => {
-    if (lineItems) {
-      if (lineItems.length > 0) {
-        const qty = getLineItemsCount({ lineItems: lineItems || [] })
-        setQuantity(qty)
-      } else {
-        setQuantity(0)
-      }
-    }
-    return (): void => {
-      setQuantity(undefined)
-    }
+  const quantity = useMemo(() => {
+    if (lineItems == null) return undefined
+    return getLineItemsCount({ lineItems })
   }, [lineItems])
+  const emptyText = quantity === 0 ? <span {...p}>{text}</span> : null
   const parentProps = {
     quantity,
     text,

--- a/packages/react-components/src/components/line_items/LineItemsEmpty.tsx
+++ b/packages/react-components/src/components/line_items/LineItemsEmpty.tsx
@@ -1,8 +1,8 @@
-import { useContext, useMemo, type JSX } from "react"
+import { type JSX, useContext, useMemo } from "react"
 import Parent from "#components/utils/Parent"
-import getLineItemsCount from "#utils/getLineItemsCount"
 import LineItemContext from "#context/LineItemContext"
 import type { ChildrenFunction } from "#typings/index"
+import getLineItemsCount from "#utils/getLineItemsCount"
 
 interface ChildrenProps extends Omit<Props, "children"> {
   quantity: number


### PR DESCRIPTION
## Summary
- Replace synchronous `useState+useEffect` patterns with `useMemo` in `LineItemAmount`, `LineItemsCount`, `LineItemsEmpty`
- Fix `as any` → `ElementType` typing in `LineItemOption` and `LineItemOptions`
- `LineItemOptions`: use `sku_option.id` static SDK attribute instead of dynamic `skuOption()` accessor
- `LineItemRemoveLink`: replace `<a href="#">` with `<button type="button">` (a11y fix)
- `LineItemsContainer` (deprecated): fix `noExplicitAny`, import sorting, `useEffect` dependency
- Add exhaustive specs for all line item child components with shared test helpers
- All 70 tests passing at 100% coverage

## Verification
```bash
cd packages/react-components && node_modules/.bin/vitest run specs/line_items
```

## Notes
- `LineItemsContainer.tsx` is deprecated (marked `@deprecated`) — minimal fixes only
- Test helpers use proper SDK types (`Partial<LineItem>`, `Partial<LineItemOption>`) — no `any`
- All Biome lint/format checks pass (0 errors, 0 warnings) on the `line_items` folder