### PR TITLE
Build the libraries before the storybook

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -40,7 +40,10 @@ jobs:
         run: pnpm install
 
       - name: Build 🛠
-        run: pnpm docs:build
+        # The libraries have to be built first: the storybook resolves
+        # @commercelayer/core-components to its dist, which does not exist on a
+        # clean checkout.
+        run: pnpm build && pnpm docs:build
 
       - name: Setup Pages 🧰
         uses: actions/configure-pages@v4

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,13 @@
 
 [build]
   base = "/"
-  command = "pnpm docs:build"
+  # The libraries must be built before the storybook. Its Vite config aliases
+  # @commercelayer/react-components straight to source, but that source imports
+  # @commercelayer/core-components, which is a workspace package resolving to
+  # ./dist/index.js — absent on a clean checkout, so rolldown fails to resolve
+  # it. Locally the storybook builds without this only because dist/ is already
+  # lying around from a previous build.
+  command = "pnpm build && pnpm docs:build"
   publish = "packages/docs/storybook-static"
 
 [build.environment]


### PR DESCRIPTION
The Netlify deploy on #619 failed with:

```
Error: [vite]: Rolldown failed to resolve import
"@commercelayer/core-components" from
"/opt/build/repo/packages/react-components/src/hooks/useCommerceLayer.ts".
```

## Cause

The storybook's Vite config aliases `@commercelayer/react-components` straight to its source, which is why #815 assumed no prior build was needed. That assumption was wrong: the aliased **source** imports `@commercelayer/core-components`, a workspace package whose entry point is `./dist/index.js`, and nothing aliases *that*. On a clean checkout `dist/` does not exist, so rolldown cannot resolve it.

It passed locally only because `dist/` was left over from earlier builds. Deleting the three `dist/` directories reproduces the Netlify failure exactly — same message, same file, exit 1 — and `pnpm build` makes it pass again.

**This is not about publishing to npm.** The dependency is declared `"@commercelayer/core-components": "workspace:*"`, so pnpm links the local package and never consults the registry; the reproduction above happens with nothing published.

## Fix

`pnpm build && pnpm docs:build` in `netlify.toml`, and the same in the `gh-pages` workflow, which carried the identical latent bug — it also ran `docs:build` alone and would have failed the same way on a clean runner. It has just been re-armed with its push trigger, so it would have broken on the next push to `main`.

## Verification

Simulating a clean checkout by deleting `packages/*/dist` and running the exact command Netlify will run:

- `pnpm build && pnpm docs:build` → exit 0, `packages/docs/storybook-static` produced
- without the fix, from the same clean state → exit 1 with the error above
- `pnpm test` — 998 passed / 24 skipped

The Netlify deploy preview on #619 remains the only real end-to-end signal; it will re-run once this lands on `v5.0.0`.
