### PR TITLE
chore: bump pnpm to 11.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.24.0",
   "author": {
     "name": "Alessandro Casazza",
     "email": "alessandro@commercelayer.io"


### PR DESCRIPTION
Bumps the root `packageManager` field from `pnpm@11.22.0` to `pnpm@11.24.0`.

## Why this one line matters more than it looks

`packageManager` is the **only** source of the pnpm version for the whole project, in two places that have no fallback of their own:

- **Netlify** reads it via Corepack. There is no `PNPM_VERSION` variable to override it — this is spelled out in `netlify.toml:7`.
- **GitHub Actions** uses `pnpm/action-setup@v6` with no `version` input (e.g. `publish.yaml:19-20`), so the action resolves the version from this field. Without it the step fails outright.

So merging this moves CI and the Netlify builds to 11.24.0 together. That is the intended effect, and it is the reason the field must not be removed — `preinstall: npx only-allow pnpm` enforces *which* package manager, not which version.

## Compatibility

`pnpm-lock.yaml` stays at `lockfileVersion: 9.0`, which is unchanged across pnpm 11.x, so no lockfile churn and no reinstall required.

## Note

The `.claude/worktrees/merge-main-into-v5` worktree carries its own `package.json` still pinned at `pnpm@11.22.0`. It will pick this up when main is merged into it.