### PR TITLE
v5.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "5.0.0-beta.12",
+  "version": "5.0.0-beta.13",
   "command": {
     "version": {
       "preid": "beta"

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "5.0.0-beta.13",
+  "version": "5.0.0",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/core-components",
-  "version": "5.0.0-beta.12",
+  "version": "5.0.0-beta.13",
   "description": "Commerce Layer Core",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/core-components",
-  "version": "5.0.0-beta.13",
+  "version": "5.0.0",
   "description": "Commerce Layer Core",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "5.0.0-beta.12",
+  "version": "5.0.0-beta.13",
   "description": "The Official Commerce Layer React Components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "5.0.0-beta.13",
+  "version": "5.0.0",
   "description": "The Official Commerce Layer React Components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-hooks-components/package.json
+++ b/packages/react-hooks-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-hooks-components",
-  "version": "5.0.0-beta.12",
+  "version": "5.0.0-beta.13",
   "description": "Commerce Layer React Hooks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-hooks-components/package.json
+++ b/packages/react-hooks-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-hooks-components",
-  "version": "5.0.0-beta.13",
+  "version": "5.0.0",
   "description": "Commerce Layer React Hooks",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Graduates the three packages from `5.0.0-beta.13` to **`5.0.0`**.

Produced with `lerna version 5.0.0 --no-private --force-publish`, so all three moved together even though not all had changes of their own:

| package | from | to |
| --- | --- | --- |
| `@commercelayer/react-components` | 5.0.0-beta.13 | 5.0.0 |
| `@commercelayer/core-components` | 5.0.0-beta.13 | 5.0.0 |
| `@commercelayer/react-hooks-components` | 5.0.0-beta.13 | 5.0.0 |

The commit touches four files and one line each — the three `package.json` version fields and `lerna.json`. Cross-package dependencies stay on `workspace:*` and are resolved at publish time.

## Release state

The `v5.0.0` tag is pushed, and `release.yaml` has already opened the corresponding GitHub release **as a draft** (`prerelease: false`, correctly, since the tag carries no `beta.`). Nothing is on npm yet: `publish.yaml` only runs on `release: published`.

Worth knowing before that draft is published: `publish.yaml` runs `pnpm -r publish --access public` without `--tag next` for a non-prerelease, so 5.0.0 becomes **`latest`** on npm, moving the default install away from 4.29.7.

## Note

This branch does not include `2818e850` ("create/update merge check") from `main`, so 5.0.0 is cut from a tree one commit behind it. Flagged rather than silently merged in, since the tag is already pushed and rewriting it would be worse.