### PR TITLE
v5.0.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "5.0.1-beta.1",
+  "version": "5.0.1",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/core-components",
-  "version": "5.0.1-beta.0",
+  "version": "5.0.1",
   "description": "Commerce Layer Core",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "5.0.1-beta.1",
+  "version": "5.0.1",
   "description": "The Official Commerce Layer React Components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-hooks-components/package.json
+++ b/packages/react-hooks-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-hooks-components",
-  "version": "5.0.1-beta.0",
+  "version": "5.0.1",
   "description": "Commerce Layer React Hooks",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Graduates the three packages to **`5.0.1`**, the first patch on top of `5.0.0`.

Produced with `lerna version 5.0.1 --no-private --force-publish`, so all three moved together — `core-components` and `react-hooks-components` were still on `5.0.1-beta.0`, since `beta.1` had bumped only `react-components`.

| package | from | to |
| --- | --- | --- |
| `@commercelayer/react-components` | 5.0.1-beta.1 | 5.0.1 |
| `@commercelayer/core-components` | 5.0.1-beta.0 | 5.0.1 |
| `@commercelayer/react-hooks-components` | 5.0.1-beta.0 | 5.0.1 |

The commit touches four files and one line each — the three `package.json` version fields and `lerna.json`. Cross-package dependencies stay on `workspace:*` and are resolved at publish time.

## What's in it

Only one functional change since `5.0.0`, from #831:

- `c66d88a1` — place the order when the shopper returns from a payment redirect
- `4c9c984a` — place the order **once** when two callers race (fixes the duplicate `_place` that `c66d88a1` introduced, exercised through the two betas)

Plus `2818e850` and `bc56b030`, both CI merge-check workflow files with no runtime effect.

## Release state

The `v5.0.1` tag is pushed at `4c3f1af8` and `release.yaml` has already opened the corresponding GitHub release **as a draft** (`prerelease: false`, correctly — the tag carries no `beta.`). Nothing is on npm yet: `publish.yaml` only runs on `release: published`.

Worth knowing before that draft is published: for a non-prerelease, `publish.yaml` publishes without `--tag next`, so **5.0.1 becomes `latest`** on npm. Current dist-tags are `latest: 5.0.0`, `next: 5.0.1-beta.1`.

## Note

Unlike #828, this branch is cut from current `main` — `4c3f1af8`'s parent is `4bb34d99`, the #831 merge commit — so nothing is missing from the tagged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
