### PR TITLE
fix(hosted-cart): return to the MIT-licensed iframe-resizer v4

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -65,12 +65,13 @@
     "@commercelayer/organization-config": "^2.8.4",
     "@commercelayer/react-hooks-components": "workspace:*",
     "@commercelayer/sdk": "8.0.0-beta.11",
-    "@iframe-resizer/parent": "^5.5.9",
     "@stripe/react-stripe-js": "^6.8.1",
     "@stripe/stripe-js": "^9.10.0",
     "@tanstack/react-table": "^8.21.3",
+    "@types/iframe-resizer": "^4.0.0",
     "braintree-web": "^3.143.0",
     "frames-react": "^1.2.4",
+    "iframe-resizer": "4.3.11",
     "rapid-form": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/react-components/src/components/orders/HostedCart.tsx
+++ b/packages/react-components/src/components/orders/HostedCart.tsx
@@ -1,5 +1,5 @@
 import type { Order } from "@commercelayer/sdk"
-import iframeResizer from "@iframe-resizer/parent"
+import { iframeResizer } from "iframe-resizer"
 import {
   type CSSProperties,
   type JSX,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,9 +175,6 @@ importers:
       '@commercelayer/sdk':
         specifier: 8.0.0-beta.11
         version: 8.0.0-beta.11
-      '@iframe-resizer/parent':
-        specifier: ^5.5.9
-        version: 5.5.9
       '@stripe/react-stripe-js':
         specifier: ^6.8.1
         version: 6.8.1(@stripe/stripe-js@9.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -187,12 +184,18 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/iframe-resizer':
+        specifier: ^4.0.0
+        version: 4.0.0
       braintree-web:
         specifier: ^3.143.0
         version: 3.144.0
       frames-react:
         specifier: ^1.2.4
         version: 1.2.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      iframe-resizer:
+        specifier: 4.3.11
+        version: 4.3.11
       rapid-form:
         specifier: ^5.0.0
         version: 5.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -871,12 +874,6 @@ packages:
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@iframe-resizer/core@5.5.9':
-    resolution: {integrity: sha512-HacDQx81pgHlmY48tRogcX02TOXfvjllJzI+xfVYmvEXhxoViyi9yEobhNQEt8Mq6NmrH1vHhz6FRfQ9uBTsjQ==}
-
-  '@iframe-resizer/parent@5.5.9':
-    resolution: {integrity: sha512-DfNb9KlOf7WyCNOM2xWPGxJfWtqA/gg7sjHvqvD4k6cfpntPXrKfCd3WdOPNKA980urGkhOdM9Ye0unV2gnYYw==}
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -1982,6 +1979,9 @@ packages:
   '@types/googlepay@0.7.11':
     resolution: {integrity: sha512-njLi4oCyqYx4nT1xoZWFDnLtKVbsbZkJTzLO45X5RW3yJTgDFSg2Wj6dnuXx+ZdZa89gBLkfMIbKNnMi5Y2wpw==}
 
+  '@types/iframe-resizer@4.0.0':
+    resolution: {integrity: sha512-RKrT4goNVtqZvf9WPkV0cUcphQWXzLVW1IE4yOIY21c1W+obJJbcHFD1lQu5ncNHm/6TeQSeedVf9bmkx2NaGQ==}
+
   '@types/js-cookie@3.0.6':
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
 
@@ -2326,9 +2326,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  auto-console-group@1.3.0:
-    resolution: {integrity: sha512-W/G5jy1ZPeVYPyqOVGND7EjbzrsLgRD3s+1QegXfJ7bYlphFxjqG60rviFXWw0d2YCj0Clc7hU5/nTqrBEhBIw==}
 
   axios@1.19.0:
     resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
@@ -3071,6 +3068,10 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  iframe-resizer@4.3.11:
+    resolution: {integrity: sha512-5QtnsmfH11GDsuC7Gxd/eNzojudX3346Gb0E+Ku8ln8AtfSq+cWCZtnhCrthrtE7f1CI2/kwHkZ9G4sFYzHP7A==}
+    engines: {node: '>=0.8.0'}
 
   ignore-walk@8.0.0:
     resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
@@ -5347,15 +5348,6 @@ snapshots:
 
   '@gar/promise-retry@1.0.3': {}
 
-  '@iframe-resizer/core@5.5.9':
-    dependencies:
-      auto-console-group: 1.3.0
-
-  '@iframe-resizer/parent@5.5.9':
-    dependencies:
-      '@iframe-resizer/core': 5.5.9
-      auto-console-group: 1.3.0
-
   '@inquirer/ansi@1.0.2': {}
 
   '@inquirer/ansi@2.0.7': {}
@@ -6377,6 +6369,8 @@ snapshots:
 
   '@types/googlepay@0.7.11': {}
 
+  '@types/iframe-resizer@4.0.0': {}
+
   '@types/js-cookie@3.0.6': {}
 
   '@types/jsesc@2.5.1': {}
@@ -6666,8 +6660,6 @@ snapshots:
       js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
-
-  auto-console-group@1.3.0: {}
 
   axios@1.19.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
@@ -7397,6 +7389,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  iframe-resizer@4.3.11: {}
 
   ignore-walk@8.0.0:
     dependencies:


### PR DESCRIPTION
## Why

`@iframe-resizer/parent@5.5.9` is licensed **GPL-3.0**, and it pulls `@iframe-resizer/core@5.5.9` (also GPL-3.0) transitively. This package is published under **MIT**, so shipping either as a runtime dependency puts the two licenses in conflict for every consumer of `@commercelayer/react-components`.

This is not a regression introduced by 1022c3a1: the dependency it replaced, unscoped `iframe-resizer@5.5.9`, is GPL-3.0 as well. The GPL line has been in the published package since the 5.x entry point was adopted, and **`@commercelayer/react-components@5.0.1` is currently on npm declaring MIT while depending on it**. A patch release is needed once this lands.

## What changed

- `@iframe-resizer/parent@^5.5.9` → `iframe-resizer@4.3.11`, the last line published under MIT (4.4.5 is also MIT if you prefer to track the latest v4; the pin here is exact so the dependency cannot silently drift into 5.x).
- Restored the `@types/iframe-resizer@^4.0.0` stub that v4 needs, since v4 does not ship its own types.
- `HostedCart.tsx` import back to the v4 named export.

The call site is untouched: v4 exports `iframeResizer` with the same `(options, target)` signature, so `iframeResizer({ checkOrigin, onMessage }, ref.current)` works as-is.

## Verification

Run on this branch against a clean install:

- `pnpm build` — green, `check-compiler` included (React Compiler output present in both `dist/index.js` and `dist/index.cjs`).
- `pnpm check-exports` — green on all four resolution modes (node10, node16 CJS, node16 ESM, bundler).
- `pnpm lint` — 97 warnings, 6 infos, no errors; identical to `main`.
- `dist/index.js` and `dist/index.cjs` contain **zero** references to `@iframe-resizer/parent`, and now reference `iframe-resizer`.
- Lockfile diff is scoped to exactly this change: drops `@iframe-resizer/parent@5.5.9` and `@iframe-resizer/core@5.5.9`, adds `iframe-resizer@4.3.11` and `@types/iframe-resizer@4.0.0`.

### It also clears a pre-existing type error

`pnpm typecheck` on `main` reports **73** errors; on this branch, **72**. The one that disappears is in the file this PR touches:

```
src/components/orders/HostedCart.tsx(298,7): error TS2345:
  Argument of type '{ checkOrigin: false; onMessage: (data: IframeData) => void; }'
  is not assignable to parameter of type 'IFrameOptions'.
```

The v5 typings rejected the options object passed to the resizer; the v4 types accept it. The remaining 72 errors are unchanged from `main` and unrelated (mostly `@commercelayer/core-components` resolution before the sibling packages are built, plus index-signature strictness). `typecheck` is not part of the `ci` script, so none of them gate this PR.

## Follow-up, not in this PR

- A **5.0.2 patch release**, since 5.0.1 is published with the GPL dependency.
- Worth considering a guard so the GPL line cannot be reintroduced — a license check in CI, or a `pnpm.overrides`/deny entry for the `@iframe-resizer/*` scope.
- `@types/iframe-resizer` is restored to `dependencies`, which is where it was before 1022c3a1. It arguably belongs in `devDependencies`, since no iframe-resizer type reaches the public API — deliberately left alone here to keep this diff a pure license fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
