### PR TITLE
v5.0.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "npmClient": "pnpm",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/core-components",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Commerce Layer Core",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-components",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "The Official Commerce Layer React Components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-hooks-components/package.json
+++ b/packages/react-hooks-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/react-hooks-components",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Commerce Layer React Hooks",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Graduates the three packages to **`5.0.2`**, a patch on top of `5.0.1`.

| package | from | to |
| --- | --- | --- |
| `@commercelayer/react-components` | 5.0.1 | 5.0.2 |
| `@commercelayer/core-components` | 5.0.1 | 5.0.2 |
| `@commercelayer/react-hooks-components` | 5.0.1 | 5.0.2 |

One commit, `a85e2bd6`, touching four files and one line each — the three `package.json` version fields and `lerna.json`. Cross-package dependencies stay on `workspace:*` and are resolved at publish time.

## ⚠️ The tag is cut from `v5.0.1`, not current `main`

`a85e2bd6`'s parent is `4c3f1af8` — the `v5.0.1` commit — not the tip of `main`. So the tagged tree predates the three PRs merged into `main` today:

- `f9cfa0c7` — #835, `fix(hosted-cart)`: return to the MIT-licensed iframe-resizer v4
- `593202a2` — #836, `fix(exports)`: add root exports missing after the subpath removal
- `97b7e964` — #837, `docs(upgrading-from-v4)`: scope the "nothing was removed" claim

`publish.yaml` runs on `release: published` and checks out the release's own commit (no explicit `ref`), which is `a85e2bd6`. Publishing the current `v5.0.2` draft as it stands would therefore ship **code identical to `5.0.1`** — and make it `latest` on npm, since the tag carries no `beta.` and `publish.yaml` omits `--tag next` for non-prereleases.

Merging this PR fixes `main` — the version fields move forward and the three fixes are already there — but it does **not** move the tag. To actually ship the fixes as `5.0.2`, the `v5.0.2` tag has to be re-pointed at this PR's merge commit and the draft release re-targeted (or deleted and re-created) *before* it is published.

## Release state

- tag `v5.0.2` → `a85e2bd6`, already pushed to `origin`
- GitHub release `v5.0.2` — **draft**, `prerelease: false` (correct: the tag has no `beta.`)
- nothing on npm yet. Current dist-tags: `latest: 5.0.1` for all three packages; `next: 5.0.1-beta.1` for `react-components`, `5.0.1-beta.0` for the other two

🤖 Generated with [Claude Code](https://claude.com/claude-code)
